### PR TITLE
feat(adapters): add trajectory logging and GEM episode runner

### DIFF
--- a/scripts/run_gem_episode.py
+++ b/scripts/run_gem_episode.py
@@ -1,0 +1,93 @@
+"""Run a single GEM episode and persist a validated trajectory log."""
+
+from __future__ import annotations
+
+import argparse
+
+import gem
+import gem.envs
+
+from trajectory_aware_gym.adapters import TrajectoryLogger
+from trajectory_aware_gym.config import GEMConfig
+
+
+def choose_guess(observation: str, low: int, high: int) -> tuple[int, int, int]:
+    """Choose next guess based on environment hint text."""
+    normalized = observation.lower()
+    if "higher than" in normalized:
+        marker = "higher than"
+        pivot = int(normalized.split(marker, maxsplit=1)[1].split(".", maxsplit=1)[0].strip())
+        low = max(low, pivot + 1)
+    elif "lower than" in normalized:
+        marker = "lower than"
+        pivot = int(normalized.split(marker, maxsplit=1)[1].split(".", maxsplit=1)[0].strip())
+        high = min(high, pivot - 1)
+
+    guess = (low + high) // 2
+    return guess, low, high
+
+
+def run_episode(environment_id: str, seed: int | None = None) -> tuple[float, int, str]:
+    """Execute one episode and save a trajectory log to disk."""
+    config = GEMConfig(_env_file=None)
+    env = gem.make(environment_id)
+
+    reset_kwargs = {"seed": seed} if seed is not None else {}
+    observation, info = env.reset(**reset_kwargs)
+
+    logger = TrajectoryLogger(environment_id=environment_id, seed=seed)
+    logger.set_initial_state(observation=observation, info=info)
+
+    total_reward = 0.0
+    low, high = 1, 10
+
+    for _ in range(config.gem_max_steps):
+        guess, low, high = choose_guess(observation, low, high)
+        action = f"\\\\boxed{{{guess}}}"
+
+        observation, reward, terminated, truncated, step_info = env.step(action)
+        logger.add_step(
+            action=action,
+            observation=observation,
+            reward=reward,
+            terminated=terminated,
+            truncated=truncated,
+            info=step_info,
+        )
+
+        total_reward += reward
+        if terminated or truncated:
+            break
+
+    log_path = logger.save()
+
+    if hasattr(env, "close"):
+        env.close()
+
+    return total_reward, len(logger.steps), str(log_path)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Run one GEM episode and log trajectory.")
+    parser.add_argument(
+        "--environment",
+        default="game:GuessTheNumber-v0-easy",
+        help="GEM environment id",
+    )
+    parser.add_argument("--seed", type=int, default=123, help="Seed for environment reset")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    args = parse_args()
+    total_reward, steps, log_path = run_episode(args.environment, args.seed)
+    print(f"Environment: {args.environment}")
+    print(f"Steps: {steps}")
+    print(f"Total reward: {total_reward:.3f}")
+    print(f"Trajectory log: {log_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_gem_episode.py
+++ b/scripts/run_gem_episode.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import argparse
-
-import gem
-import gem.envs
+import importlib
 
 from trajectory_aware_gym.adapters import TrajectoryLogger
 from trajectory_aware_gym.config import GEMConfig
@@ -30,6 +28,8 @@ def choose_guess(observation: str, low: int, high: int) -> tuple[int, int, int]:
 def run_episode(environment_id: str, seed: int | None = None) -> tuple[float, int, str]:
     """Execute one episode and save a trajectory log to disk."""
     config = GEMConfig(_env_file=None)
+    gem = importlib.import_module("gem")
+    importlib.import_module("gem.envs")
     env = gem.make(environment_id)
 
     reset_kwargs = {"seed": seed} if seed is not None else {}

--- a/src/trajectory_aware_gym/adapters/__init__.py
+++ b/src/trajectory_aware_gym/adapters/__init__.py
@@ -1,0 +1,9 @@
+"""Adapter modules for GEM integration and trajectory handling."""
+
+from trajectory_aware_gym.adapters.trajectory_logger import (
+    TrajectoryLog,
+    TrajectoryLogger,
+    TrajectoryStep,
+)
+
+__all__ = ["TrajectoryStep", "TrajectoryLog", "TrajectoryLogger"]

--- a/src/trajectory_aware_gym/adapters/trajectory_logger.py
+++ b/src/trajectory_aware_gym/adapters/trajectory_logger.py
@@ -1,0 +1,134 @@
+"""Trajectory logging utilities for GEM environment episodes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from trajectory_aware_gym.config import ProjectPaths
+
+
+class TrajectoryStep(BaseModel):
+    """Single transition in an environment trajectory."""
+
+    step_index: int = Field(ge=1)
+    action: str = Field(min_length=1)
+    observation: str = Field(min_length=1)
+    reward: float
+    terminated: bool
+    truncated: bool
+    info: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("action", "observation")
+    @classmethod
+    def strip_and_validate_text(cls, value: str) -> str:
+        """Normalize and validate required text fields."""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("must not be blank")
+        return normalized
+
+
+class TrajectoryLog(BaseModel):
+    """Validated schema for a single GEM episode trajectory."""
+
+    run_id: str = Field(default_factory=lambda: str(uuid4()))
+    environment_id: str = Field(min_length=1)
+    seed: int | None = None
+    started_at: datetime
+    finished_at: datetime
+    initial_observation: str = Field(min_length=1)
+    initial_info: dict[str, Any] = Field(default_factory=dict)
+    steps: list[TrajectoryStep] = Field(default_factory=list)
+    total_reward: float
+
+    @field_validator("environment_id", "initial_observation")
+    @classmethod
+    def strip_and_validate_text(cls, value: str) -> str:
+        """Normalize and validate required text fields."""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("must not be blank")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> TrajectoryLog:
+        """Ensure aggregate values match per-step records."""
+        if self.finished_at < self.started_at:
+            raise ValueError("finished_at must be greater than or equal to started_at")
+
+        computed_total = sum(step.reward for step in self.steps)
+        if abs(self.total_reward - computed_total) > 1e-9:
+            raise ValueError("total_reward must equal the sum of step rewards")
+
+        return self
+
+
+class TrajectoryLogger:
+    """Collects and persists validated trajectory logs for one episode."""
+
+    def __init__(self, environment_id: str, seed: int | None = None):
+        self.environment_id = environment_id
+        self.seed = seed
+        self.started_at = datetime.now(UTC)
+        self.initial_observation: str | None = None
+        self.initial_info: dict[str, Any] = {}
+        self.steps: list[TrajectoryStep] = []
+
+    def set_initial_state(self, observation: str, info: dict[str, Any] | None = None) -> None:
+        """Store initial state from env.reset()."""
+        self.initial_observation = observation
+        self.initial_info = info or {}
+
+    def add_step(
+        self,
+        *,
+        action: str,
+        observation: str,
+        reward: float,
+        terminated: bool,
+        truncated: bool,
+        info: dict[str, Any] | None = None,
+    ) -> TrajectoryStep:
+        """Append a validated transition to the trajectory."""
+        step = TrajectoryStep(
+            step_index=len(self.steps) + 1,
+            action=action,
+            observation=observation,
+            reward=reward,
+            terminated=terminated,
+            truncated=truncated,
+            info=info or {},
+        )
+        self.steps.append(step)
+        return step
+
+    def build_log(self) -> TrajectoryLog:
+        """Build and validate a complete trajectory log."""
+        if self.initial_observation is None:
+            raise ValueError("initial state is not set; call set_initial_state() first")
+
+        return TrajectoryLog(
+            environment_id=self.environment_id,
+            seed=self.seed,
+            started_at=self.started_at,
+            finished_at=datetime.now(UTC),
+            initial_observation=self.initial_observation,
+            initial_info=self.initial_info,
+            steps=self.steps,
+            total_reward=sum(step.reward for step in self.steps),
+        )
+
+    def save(self, project_paths: ProjectPaths | None = None) -> Path:
+        """Persist trajectory log as JSON under logs/ with timestamped filename."""
+        trajectory_log = self.build_log()
+        paths = project_paths or ProjectPaths()
+
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        file_path = paths.logs / f"trajectory_{timestamp}_{trajectory_log.run_id}.json"
+        file_path.write_text(trajectory_log.model_dump_json(indent=2), encoding="utf-8")
+        return file_path

--- a/tests/unit/test_trajectory_logger.py
+++ b/tests/unit/test_trajectory_logger.py
@@ -1,0 +1,145 @@
+"""Tests for trajectory logging and schema validation."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from trajectory_aware_gym.adapters.trajectory_logger import (
+    TrajectoryLog,
+    TrajectoryLogger,
+    TrajectoryStep,
+)
+from trajectory_aware_gym.config.settings import ProjectPaths
+
+
+class TestTrajectoryStep:
+    """Tests for trajectory step schema."""
+
+    @pytest.mark.parametrize(
+        ("action", "observation", "reward", "terminated", "truncated"),
+        [
+            ("\\\\boxed{5}", "hint", 0.0, False, False),
+            ("\\\\boxed{1}", "done", 1.0, True, False),
+            ("action", "truncated", -0.5, False, True),
+        ],
+    )
+    def test_valid_step(self, action, observation, reward, terminated, truncated):
+        """Test valid step records."""
+        step = TrajectoryStep(
+            step_index=1,
+            action=action,
+            observation=observation,
+            reward=reward,
+            terminated=terminated,
+            truncated=truncated,
+            info={"suffix": "next"},
+        )
+        assert step.step_index == 1
+        assert step.action == action
+
+    @pytest.mark.parametrize(
+        ("action", "observation"),
+        [
+            ("", "valid"),
+            ("   ", "valid"),
+            ("valid", ""),
+            ("valid", "   "),
+        ],
+    )
+    def test_blank_text_rejected(self, action, observation):
+        """Test blank action/observation raises validation error."""
+        with pytest.raises(ValidationError):
+            TrajectoryStep(
+                step_index=1,
+                action=action,
+                observation=observation,
+                reward=0.0,
+                terminated=False,
+                truncated=False,
+            )
+
+
+class TestTrajectoryLog:
+    """Tests for aggregate trajectory log schema."""
+
+    def test_total_reward_must_match_steps(self):
+        """Test total reward consistency validation."""
+        now = datetime.now(UTC)
+        with pytest.raises(ValidationError):
+            TrajectoryLog(
+                environment_id="game:GuessTheNumber-v0-easy",
+                seed=1,
+                started_at=now,
+                finished_at=now + timedelta(seconds=1),
+                initial_observation="start",
+                steps=[
+                    TrajectoryStep(
+                        step_index=1,
+                        action="\\\\boxed{5}",
+                        observation="higher",
+                        reward=0.5,
+                        terminated=False,
+                        truncated=False,
+                    )
+                ],
+                total_reward=0.4,
+            )
+
+    def test_finished_at_cannot_precede_started_at(self):
+        """Test timestamp ordering validation."""
+        now = datetime.now(UTC)
+        with pytest.raises(ValidationError):
+            TrajectoryLog(
+                environment_id="game:GuessTheNumber-v0-easy",
+                seed=1,
+                started_at=now,
+                finished_at=now - timedelta(seconds=1),
+                initial_observation="start",
+                steps=[],
+                total_reward=0.0,
+            )
+
+
+class TestTrajectoryLogger:
+    """Tests for logger collection and persistence."""
+
+    def test_save_writes_json_log(self, tmp_path):
+        """Test save persists a valid JSON trajectory in logs directory."""
+        paths = ProjectPaths(root=tmp_path)
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy", seed=42)
+        logger.set_initial_state("start", {"suffix": "next"})
+        logger.add_step(
+            action="\\\\boxed{5}",
+            observation="lower",
+            reward=0.0,
+            terminated=False,
+            truncated=False,
+            info={"suffix": "next"},
+        )
+        logger.add_step(
+            action="\\\\boxed{1}",
+            observation="win",
+            reward=1.0,
+            terminated=True,
+            truncated=False,
+            info={"suffix": "next"},
+        )
+
+        file_path = logger.save(project_paths=paths)
+        assert file_path.exists()
+        assert file_path.parent == paths.logs
+
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+        assert payload["environment_id"] == "game:GuessTheNumber-v0-easy"
+        assert payload["total_reward"] == 1.0
+        assert len(payload["steps"]) == 2
+
+    def test_build_log_requires_initial_state(self):
+        """Test logger raises if reset state was never captured."""
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        with pytest.raises(ValueError, match="initial state is not set"):
+            logger.build_log()


### PR DESCRIPTION
## Summary
This PR adds a minimal, validated trajectory logging flow for GEM episodes using GuessTheNumber-v0-easy.

### What changed
- Added Pydantic trajectory schema (`TrajectoryStep`, `TrajectoryLog`)
- Added `TrajectoryLogger` to capture reset state, per-step transitions, and save timestamped JSON logs under `logs/`
- Added `scripts/run_gem_episode.py` to run one GEM episode in `game:GuessTheNumber-v0-easy` with trajectory capture
- Added unit tests for schema validation and logging persistence
- Follow-up fix: switched to runtime `importlib` loading for `gem`/`gem.envs` to resolve editor import diagnostics

### Validation
- `uv run python scripts/run_gem_episode.py --seed 123`
- `uv run poe lint`
- `uv run poe test`

### Checklist
- [x] Explored repository structure and GEM integration entry points
- [x] Defined trajectory log schema with Pydantic
- [x] Implemented trajectory logger with schema validation
- [x] Added single-episode GEM runner script
- [x] Captured trajectory during episode execution
- [x] Saved logs locally with timestamp under `logs/`
- [x] Added unit tests for logging and schema validation
- [x] Manually verified single run execution
- [x] Ran linter and full test suite
- [ ] Reviewer(s) assigned
