### PR TITLE
feat(trajectory-logging): extend trajectory schema with LLM/tool call…

### DIFF
--- a/scripts/run_gem_episode.py
+++ b/scripts/run_gem_episode.py
@@ -1,9 +1,16 @@
-"""Run a single GEM episode and persist a validated trajectory log."""
+"""Run a single GEM episode and persist a validated trajectory log.
+
+Demonstrates the extended trajectory logging schema (F1/F2) with:
+- Optional system prompt tracking
+- Episode outcome derivation
+- Per-step timestamps
+"""
 
 from __future__ import annotations
 
 import argparse
 import importlib
+import json
 
 from trajectory_aware_gym.adapters import TrajectoryLogger
 from trajectory_aware_gym.config import GEMConfig
@@ -25,7 +32,11 @@ def choose_guess(observation: str, low: int, high: int) -> tuple[int, int, int]:
     return guess, low, high
 
 
-def run_episode(environment_id: str, seed: int | None = None) -> tuple[float, int, str]:
+def run_episode(
+    environment_id: str,
+    seed: int | None = None,
+    system_prompt: str | None = None,
+) -> tuple[float, int, str]:
     """Execute one episode and save a trajectory log to disk."""
     config = GEMConfig(_env_file=None)
     gem = importlib.import_module("gem")
@@ -36,6 +47,8 @@ def run_episode(environment_id: str, seed: int | None = None) -> tuple[float, in
     observation, info = env.reset(**reset_kwargs)
 
     logger = TrajectoryLogger(environment_id=environment_id, seed=seed)
+    if system_prompt:
+        logger.set_system_prompt(system_prompt)
     logger.set_initial_state(observation=observation, info=info)
 
     total_reward = 0.0
@@ -76,17 +89,31 @@ def parse_args() -> argparse.Namespace:
         help="GEM environment id",
     )
     parser.add_argument("--seed", type=int, default=123, help="Seed for environment reset")
+    parser.add_argument("--system-prompt", type=str, default=None, help="System prompt to log")
+    parser.add_argument("--show-log", action="store_true", help="Print the full JSON log")
     return parser.parse_args()
 
 
 def main() -> None:
     """CLI entrypoint."""
     args = parse_args()
-    total_reward, steps, log_path = run_episode(args.environment, args.seed)
-    print(f"Environment: {args.environment}")
-    print(f"Steps: {steps}")
-    print(f"Total reward: {total_reward:.3f}")
+    total_reward, steps, log_path = run_episode(
+        args.environment,
+        args.seed,
+        args.system_prompt,
+    )
+    print(f"Environment:    {args.environment}")
+    print(f"Steps:          {steps}")
+    print(f"Total reward:   {total_reward:.3f}")
     print(f"Trajectory log: {log_path}")
+
+    if args.show_log:
+        from pathlib import Path
+
+        payload = json.loads(Path(log_path).read_text(encoding="utf-8"))
+        print(f"\nSchema version: {payload['schema_version']}")
+        print(f"Outcome:        {payload['episode_outcome']}")
+        print(f"System prompt:  {payload.get('system_prompt', '(none)')}")
 
 
 if __name__ == "__main__":

--- a/src/trajectory_aware_gym/adapters/__init__.py
+++ b/src/trajectory_aware_gym/adapters/__init__.py
@@ -1,9 +1,23 @@
 """Adapter modules for GEM integration and trajectory handling."""
 
 from trajectory_aware_gym.adapters.trajectory_logger import (
+    LLMCallMetadata,
+    ToolCall,
     TrajectoryLog,
     TrajectoryLogger,
     TrajectoryStep,
+    filter_trajectories,
+    load_all_trajectories,
+    load_trajectory,
 )
 
-__all__ = ["TrajectoryStep", "TrajectoryLog", "TrajectoryLogger"]
+__all__ = [
+    "LLMCallMetadata",
+    "ToolCall",
+    "TrajectoryLog",
+    "TrajectoryLogger",
+    "TrajectoryStep",
+    "filter_trajectories",
+    "load_all_trajectories",
+    "load_trajectory",
+]

--- a/src/trajectory_aware_gym/adapters/trajectory_logger.py
+++ b/src/trajectory_aware_gym/adapters/trajectory_logger.py
@@ -1,15 +1,67 @@
-"""Trajectory logging utilities for GEM environment episodes."""
+"""Trajectory logging utilities for GEM environment episodes.
+
+Schema version history:
+    1.0.0 - Initial schema with tool call tracking, LLM metadata, and cost aggregation.
+"""
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from trajectory_aware_gym.config import ProjectPaths
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1.0.0"
+
+type EpisodeOutcome = Literal["success", "failure", "truncated"]
+
+
+class ToolCall(BaseModel):
+    """A single tool invocation within an episode step."""
+
+    tool_name: str = Field(min_length=1)
+    tool_input: str
+    tool_output: str
+    success: bool
+    duration_ms: float | None = None
+
+    @field_validator("tool_name")
+    @classmethod
+    def strip_and_validate_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("tool_name must not be blank")
+        return normalized
+
+
+class LLMCallMetadata(BaseModel):
+    """Token usage and cost metadata for a single LLM call."""
+
+    model_id: str = Field(min_length=1)
+    prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    cost_usd: float | None = None
+    latency_ms: float | None = None
+
+    @model_validator(mode="after")
+    def validate_token_sum(self) -> LLMCallMetadata:
+        expected = self.prompt_tokens + self.completion_tokens
+        if self.total_tokens != expected:
+            raise ValueError(
+                f"total_tokens ({self.total_tokens}) must equal "
+                f"prompt_tokens + completion_tokens ({expected})"
+            )
+        return self
 
 
 class TrajectoryStep(BaseModel):
@@ -22,6 +74,20 @@ class TrajectoryStep(BaseModel):
     terminated: bool
     truncated: bool
     info: dict[str, Any] = Field(default_factory=dict)
+    timestamp: datetime | None = None
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    # Assumes at most one LLM call per env step. F3 (DSPy integration) may need
+    # llm_calls: list[LLMCallMetadata] if DSPy issues multiple forward() per step.
+    llm_call: LLMCallMetadata | None = None
+
+    @field_validator("reward")
+    @classmethod
+    def reject_non_finite_reward(cls, value: float) -> float:
+        import math
+
+        if not math.isfinite(value):
+            raise ValueError(f"reward must be finite, got {value}")
+        return value
 
     @field_validator("action", "observation")
     @classmethod
@@ -36,15 +102,22 @@ class TrajectoryStep(BaseModel):
 class TrajectoryLog(BaseModel):
     """Validated schema for a single GEM episode trajectory."""
 
+    schema_version: str = SCHEMA_VERSION
     run_id: str = Field(default_factory=lambda: str(uuid4()))
     environment_id: str = Field(min_length=1)
     seed: int | None = None
+    # The GEPA-level prompt. Per-step LLM prompts (if needed) should be stored separately.
+    system_prompt: str | None = None
     started_at: datetime
     finished_at: datetime
     initial_observation: str = Field(min_length=1)
     initial_info: dict[str, Any] = Field(default_factory=dict)
     steps: list[TrajectoryStep] = Field(default_factory=list)
     total_reward: float
+    num_steps: int = 0
+    episode_outcome: EpisodeOutcome | None = None
+    total_tokens: int = 0
+    total_cost_usd: float = 0.0
 
     @field_validator("environment_id", "initial_observation")
     @classmethod
@@ -65,24 +138,88 @@ class TrajectoryLog(BaseModel):
         if abs(self.total_reward - computed_total) > 1e-9:
             raise ValueError("total_reward must equal the sum of step rewards")
 
+        if self.num_steps != len(self.steps):
+            raise ValueError(
+                f"num_steps ({self.num_steps}) must equal len(steps) ({len(self.steps)})"
+            )
+
+        computed_tokens = sum(step.llm_call.total_tokens for step in self.steps if step.llm_call)
+        if self.total_tokens != computed_tokens:
+            raise ValueError(
+                f"total_tokens ({self.total_tokens}) must equal "
+                f"sum of step tokens ({computed_tokens})"
+            )
+
+        computed_cost = sum(
+            step.llm_call.cost_usd
+            for step in self.steps
+            if step.llm_call and step.llm_call.cost_usd is not None
+        )
+        if abs(self.total_cost_usd - computed_cost) > 1e-9:
+            raise ValueError(
+                f"total_cost_usd ({self.total_cost_usd}) must equal "
+                f"sum of step costs ({computed_cost})"
+            )
+
         return self
+
+
+# GEM envs provide ground-truth success in info (e.g., MathEnv: {"correct": bool}).
+# We check these keys first; reward > 0 is only a fallback when no explicit signal exists.
+_SUCCESS_INFO_KEYS = ("correct", "is_correct", "success", "task_success")
+
+
+def _derive_outcome(steps: list[TrajectoryStep]) -> EpisodeOutcome | None:
+    """Derive episode outcome from the final step's info dict and termination signals.
+
+    Priority order:
+        1. Explicit success signal in info dict (ground truth from GEM env)
+        2. truncated flag (takes precedence; GEM game envs may set both flags on final turn)
+        3. terminated flag with reward > 0 as fallback heuristic
+    """
+    if not steps:
+        return None
+    final = steps[-1]
+
+    for key in _SUCCESS_INFO_KEYS:
+        if key in final.info:
+            return "success" if bool(final.info[key]) else "failure"
+
+    # truncated takes precedence: GEM game envs may set both flags on the final turn.
+    if final.truncated:
+        return "truncated"
+
+    if final.terminated:
+        return "success" if final.reward > 0 else "failure"
+
+    return None
 
 
 class TrajectoryLogger:
     """Collects and persists validated trajectory logs for one episode."""
 
-    def __init__(self, environment_id: str, seed: int | None = None):
+    def __init__(
+        self,
+        environment_id: str,
+        seed: int | None = None,
+    ):
         self.environment_id = environment_id
         self.seed = seed
+        self.system_prompt: str | None = None
         self.started_at = datetime.now(UTC)
         self.initial_observation: str | None = None
         self.initial_info: dict[str, Any] = {}
         self.steps: list[TrajectoryStep] = []
 
     def set_initial_state(self, observation: str, info: dict[str, Any] | None = None) -> None:
-        """Store initial state from env.reset()."""
+        if self.initial_observation is not None:
+            raise RuntimeError("Initial state has already been set; cannot overwrite.")
         self.initial_observation = observation
         self.initial_info = info or {}
+
+    def set_system_prompt(self, prompt: str) -> None:
+        """Store the system prompt used for this episode (the GEPA independent variable)."""
+        self.system_prompt = prompt
 
     def add_step(
         self,
@@ -93,6 +230,9 @@ class TrajectoryLogger:
         terminated: bool,
         truncated: bool,
         info: dict[str, Any] | None = None,
+        timestamp: datetime | None = None,
+        tool_calls: list[ToolCall] | None = None,
+        llm_call: LLMCallMetadata | None = None,
     ) -> TrajectoryStep:
         """Append a validated transition to the trajectory."""
         step = TrajectoryStep(
@@ -103,6 +243,9 @@ class TrajectoryLogger:
             terminated=terminated,
             truncated=truncated,
             info=info or {},
+            timestamp=timestamp or datetime.now(UTC),
+            tool_calls=tool_calls or [],
+            llm_call=llm_call,
         )
         self.steps.append(step)
         return step
@@ -112,23 +255,81 @@ class TrajectoryLogger:
         if self.initial_observation is None:
             raise ValueError("initial state is not set; call set_initial_state() first")
 
+        total_tokens = sum(s.llm_call.total_tokens for s in self.steps if s.llm_call)
+        total_cost = sum(
+            s.llm_call.cost_usd
+            for s in self.steps
+            if s.llm_call and s.llm_call.cost_usd is not None
+        )
+
         return TrajectoryLog(
             environment_id=self.environment_id,
             seed=self.seed,
+            system_prompt=self.system_prompt,
             started_at=self.started_at,
             finished_at=datetime.now(UTC),
             initial_observation=self.initial_observation,
             initial_info=self.initial_info,
             steps=self.steps,
             total_reward=sum(step.reward for step in self.steps),
+            num_steps=len(self.steps),
+            episode_outcome=_derive_outcome(self.steps),
+            total_tokens=total_tokens,
+            total_cost_usd=total_cost,
         )
 
     def save(self, project_paths: ProjectPaths | None = None) -> Path:
-        """Persist trajectory log as JSON under logs/ with timestamped filename."""
+        """Persist trajectory log as JSON under logs/ with timestamped filename.
+        Creates the logs directory if it doesn't exist.
+        Writes to a temporary file first and then atomically replaces the existing file.
+        This ensures the file is always in a valid state and avoids partial writes.
+        """
         trajectory_log = self.build_log()
         paths = project_paths or ProjectPaths()
 
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
         file_path = paths.logs / f"trajectory_{timestamp}_{trajectory_log.run_id}.json"
-        file_path.write_text(trajectory_log.model_dump_json(indent=2), encoding="utf-8")
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        tmp_path = file_path.with_suffix(".json.tmp")
+        tmp_path.write_text(trajectory_log.model_dump_json(indent=2), encoding="utf-8")
+        os.replace(tmp_path, file_path)
         return file_path
+
+
+# ---------------------------------------------------------------------------
+# Trajectory loading utilities (F2)
+# ---------------------------------------------------------------------------
+
+
+def load_trajectory(path: Path | str) -> TrajectoryLog:
+    """Deserialize a trajectory log from a JSON file."""
+    p = Path(path)
+    return TrajectoryLog.model_validate_json(p.read_text(encoding="utf-8"))
+
+
+def load_all_trajectories(directory: Path | str) -> list[TrajectoryLog]:
+    """Load all trajectory JSON logs from a directory, sorted by started_at."""
+    d = Path(directory)
+    logs: list[TrajectoryLog] = []
+    for p in d.glob("trajectory_*.json"):
+        try:
+            logs.append(TrajectoryLog.model_validate_json(p.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, ValidationError) as exc:
+            logger.warning("Skipping corrupt trajectory %s: %s", p, exc)
+    return sorted(logs, key=lambda t: t.started_at)
+
+
+def filter_trajectories(
+    logs: list[TrajectoryLog],
+    *,
+    outcome: EpisodeOutcome | None = None,
+    environment_id: str | None = None,
+) -> list[TrajectoryLog]:
+    """Filter trajectory logs by outcome or environment ID."""
+    result = logs
+    if outcome is not None:
+        result = [t for t in result if t.episode_outcome == outcome]
+    if environment_id is not None:
+        result = [t for t in result if t.environment_id == environment_id]
+    return result

--- a/tests/unit/test_trajectory_logger.py
+++ b/tests/unit/test_trajectory_logger.py
@@ -1,19 +1,195 @@
-"""Tests for trajectory logging and schema validation."""
+"""Tests for trajectory logging and schema validation.
+
+Deferred test ideas (P4+, not critical for current project phase):
+- TODO(P4): Two loggers saving to same directory don't collide (UUID4 in filename should prevent)
+- TODO(P4): 1000-step episode builds/serializes correctly (stress test)
+- TODO(P4): Round-trip test with full model_dump() equality instead of field-by-field
+- TODO(P4): episode_outcome="unknown" rejected by Literal type
+- TODO(P4): Decouple _make_log helper from production aggregation logic
+"""
 
 from __future__ import annotations
 
 import json
+import math
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
 from trajectory_aware_gym.adapters.trajectory_logger import (
+    SCHEMA_VERSION,
+    LLMCallMetadata,
+    ToolCall,
     TrajectoryLog,
     TrajectoryLogger,
     TrajectoryStep,
+    _derive_outcome,
+    filter_trajectories,
+    load_all_trajectories,
+    load_trajectory,
 )
-from trajectory_aware_gym.config.settings import ProjectPaths
+from trajectory_aware_gym.config import ProjectPaths
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_step(
+    step_index: int = 1,
+    *,
+    reward: float = 0.0,
+    terminated: bool = False,
+    truncated: bool = False,
+    info: dict[str, Any] | None = None,
+    tool_calls: list[ToolCall] | None = None,
+    llm_call: LLMCallMetadata | None = None,
+    timestamp: datetime | None = None,
+) -> TrajectoryStep:
+    return TrajectoryStep(
+        step_index=step_index,
+        action="act",
+        observation="obs",
+        reward=reward,
+        terminated=terminated,
+        truncated=truncated,
+        info=info or {},
+        tool_calls=tool_calls or [],
+        llm_call=llm_call,
+        timestamp=timestamp,
+    )
+
+
+def _make_llm_call(
+    prompt: int = 10,
+    completion: int = 20,
+    cost: float | None = 0.001,
+) -> LLMCallMetadata:
+    return LLMCallMetadata(
+        model_id="bedrock/qwen3-1.7b",
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+        cost_usd=cost,
+    )
+
+
+def _make_log(
+    steps: list[TrajectoryStep] | None = None,
+    **overrides,
+) -> TrajectoryLog:
+    now = datetime.now(UTC)
+    steps = steps or []
+    defaults = {
+        "environment_id": "game:GuessTheNumber-v0-easy",
+        "seed": 1,
+        "started_at": now,
+        "finished_at": now + timedelta(seconds=1),
+        "initial_observation": "start",
+        "steps": steps,
+        "total_reward": sum(s.reward for s in steps),
+        "num_steps": len(steps),
+        "total_tokens": sum(s.llm_call.total_tokens for s in steps if s.llm_call),
+        "total_cost_usd": sum(
+            s.llm_call.cost_usd for s in steps if s.llm_call and s.llm_call.cost_usd is not None
+        ),
+    }
+    defaults.update(overrides)
+    return TrajectoryLog(**defaults)
+
+
+# ===========================================================================
+# F1: Schema Model Tests
+# ===========================================================================
+
+
+class TestToolCall:
+    """Tests for the ToolCall schema."""
+
+    @pytest.mark.parametrize(
+        ("name", "inp", "out", "success", "dur"),
+        [
+            ("python_exec", "print(1)", "1", True, 50.0),
+            ("web_search", "query", "result", True, None),
+            ("shell", "ls", "file.txt", False, 120.5),
+        ],
+    )
+    def test_valid_tool_call(self, name, inp, out, success, dur):
+        tc = ToolCall(
+            tool_name=name,
+            tool_input=inp,
+            tool_output=out,
+            success=success,
+            duration_ms=dur,
+        )
+        assert tc.tool_name == name
+        assert tc.success is success
+
+    @pytest.mark.parametrize("blank_name", ["", "   "])
+    def test_blank_tool_name_rejected(self, blank_name):
+        with pytest.raises(ValidationError):
+            ToolCall(
+                tool_name=blank_name,
+                tool_input="x",
+                tool_output="y",
+                success=True,
+            )
+
+    def test_empty_input_output_allowed(self):
+        tc = ToolCall(tool_name="noop", tool_input="", tool_output="", success=True)
+        assert tc.tool_input == ""
+
+
+class TestLLMCallMetadata:
+    """Tests for the LLMCallMetadata schema."""
+
+    @pytest.mark.parametrize(
+        ("prompt", "completion", "cost", "latency"),
+        [
+            (10, 20, 0.001, 150.0),
+            (0, 0, None, None),
+            (100, 500, 0.05, 2000.0),
+        ],
+    )
+    def test_valid_metadata(self, prompt, completion, cost, latency):
+        meta = LLMCallMetadata(
+            model_id="bedrock/qwen3-1.7b",
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=prompt + completion,
+            cost_usd=cost,
+            latency_ms=latency,
+        )
+        assert meta.total_tokens == prompt + completion
+
+    def test_token_sum_mismatch_rejected(self):
+        with pytest.raises(ValidationError, match="total_tokens"):
+            LLMCallMetadata(
+                model_id="bedrock/qwen3-1.7b",
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=99,
+            )
+
+    def test_negative_tokens_rejected(self):
+        with pytest.raises(ValidationError):
+            LLMCallMetadata(
+                model_id="bedrock/qwen3-1.7b",
+                prompt_tokens=-1,
+                completion_tokens=10,
+                total_tokens=9,
+            )
+
+    def test_blank_model_id_rejected(self):
+        with pytest.raises(ValidationError):
+            LLMCallMetadata(
+                model_id="",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+            )
 
 
 class TestTrajectoryStep:
@@ -28,7 +204,6 @@ class TestTrajectoryStep:
         ],
     )
     def test_valid_step(self, action, observation, reward, terminated, truncated):
-        """Test valid step records."""
         step = TrajectoryStep(
             step_index=1,
             action=action,
@@ -51,7 +226,6 @@ class TestTrajectoryStep:
         ],
     )
     def test_blank_text_rejected(self, action, observation):
-        """Test blank action/observation raises validation error."""
         with pytest.raises(ValidationError):
             TrajectoryStep(
                 step_index=1,
@@ -62,12 +236,64 @@ class TestTrajectoryStep:
                 truncated=False,
             )
 
+    def test_step_with_tool_calls(self):
+        tc = ToolCall(
+            tool_name="python_exec",
+            tool_input="print(1+1)",
+            tool_output="2",
+            success=True,
+            duration_ms=42.0,
+        )
+        step = _make_step(tool_calls=[tc])
+        assert len(step.tool_calls) == 1
+        assert step.tool_calls[0].tool_name == "python_exec"
+
+    def test_step_with_llm_call(self):
+        meta = _make_llm_call()
+        step = _make_step(llm_call=meta)
+        assert step.llm_call is not None
+        assert step.llm_call.total_tokens == 30
+
+    def test_step_defaults_no_tool_calls_or_llm(self):
+        step = _make_step()
+        assert step.tool_calls == []
+        assert step.llm_call is None
+        assert step.timestamp is None
+
+    def test_step_with_timestamp(self):
+        ts = datetime(2026, 2, 22, 12, 0, 0, tzinfo=UTC)
+        step = _make_step(timestamp=ts)
+        assert step.timestamp == ts
+
+    @pytest.mark.parametrize("bad_index", [0, -1, -100])
+    def test_step_index_below_one_rejected(self, bad_index):
+        with pytest.raises(ValidationError):
+            TrajectoryStep(
+                step_index=bad_index,
+                action="a",
+                observation="o",
+                reward=0.0,
+                terminated=False,
+                truncated=False,
+            )
+
+    @pytest.mark.parametrize("bad_reward", [float("inf"), float("-inf"), float("nan")])
+    def test_non_finite_reward_rejected(self, bad_reward):
+        with pytest.raises(ValidationError, match="finite"):
+            TrajectoryStep(
+                step_index=1,
+                action="a",
+                observation="o",
+                reward=bad_reward,
+                terminated=False,
+                truncated=False,
+            )
+
 
 class TestTrajectoryLog:
     """Tests for aggregate trajectory log schema."""
 
     def test_total_reward_must_match_steps(self):
-        """Test total reward consistency validation."""
         now = datetime.now(UTC)
         with pytest.raises(ValidationError):
             TrajectoryLog(
@@ -76,21 +302,12 @@ class TestTrajectoryLog:
                 started_at=now,
                 finished_at=now + timedelta(seconds=1),
                 initial_observation="start",
-                steps=[
-                    TrajectoryStep(
-                        step_index=1,
-                        action="\\\\boxed{5}",
-                        observation="higher",
-                        reward=0.5,
-                        terminated=False,
-                        truncated=False,
-                    )
-                ],
+                steps=[_make_step(reward=0.5)],
                 total_reward=0.4,
+                num_steps=1,
             )
 
     def test_finished_at_cannot_precede_started_at(self):
-        """Test timestamp ordering validation."""
         now = datetime.now(UTC)
         with pytest.raises(ValidationError):
             TrajectoryLog(
@@ -101,14 +318,173 @@ class TestTrajectoryLog:
                 initial_observation="start",
                 steps=[],
                 total_reward=0.0,
+                num_steps=0,
             )
+
+    def test_schema_version_defaults(self):
+        log = _make_log()
+        assert log.schema_version == SCHEMA_VERSION
+
+    def test_num_steps_mismatch_rejected(self):
+        with pytest.raises(ValidationError, match="num_steps"):
+            _make_log(steps=[_make_step()], num_steps=5)
+
+    def test_total_tokens_mismatch_rejected(self):
+        step = _make_step(llm_call=_make_llm_call(prompt=10, completion=20))
+        with pytest.raises(ValidationError, match="total_tokens"):
+            _make_log(steps=[step], total_tokens=999)
+
+    def test_total_cost_mismatch_rejected(self):
+        step = _make_step(llm_call=_make_llm_call(cost=0.05))
+        with pytest.raises(ValidationError, match="total_cost_usd"):
+            _make_log(steps=[step], total_cost_usd=99.0)
+
+    def test_system_prompt_stored(self):
+        log = _make_log(system_prompt="You are a helpful math tutor.")
+        assert log.system_prompt == "You are a helpful math tutor."
+
+    @pytest.mark.parametrize(
+        "outcome",
+        ["success", "failure", "truncated"],
+    )
+    def test_episode_outcome_values(self, outcome):
+        log = _make_log(episode_outcome=outcome)
+        assert log.episode_outcome == outcome
+
+    def test_log_with_multiple_llm_steps(self):
+        s1 = _make_step(step_index=1, llm_call=_make_llm_call(10, 20, 0.01))
+        s2 = _make_step(step_index=2, llm_call=_make_llm_call(15, 25, 0.02))
+        log = _make_log(steps=[s1, s2])
+        assert log.total_tokens == 70
+        assert abs(log.total_cost_usd - 0.03) < 1e-9
+
+    def test_log_with_none_cost_steps(self):
+        s1 = _make_step(step_index=1, llm_call=_make_llm_call(10, 20, cost=None))
+        s2 = _make_step(step_index=2, llm_call=_make_llm_call(5, 5, cost=0.01))
+        log = _make_log(steps=[s1, s2])
+        assert abs(log.total_cost_usd - 0.01) < 1e-9
+
+    def test_backward_compatible_empty_log(self):
+        log = _make_log()
+        assert log.steps == []
+        assert log.total_tokens == 0
+        assert log.total_cost_usd == 0.0
+        assert log.episode_outcome is None
+        assert log.system_prompt is None
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_environment_id_rejected(self, blank):
+        with pytest.raises(ValidationError):
+            _make_log(environment_id=blank)
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_initial_observation_rejected(self, blank):
+        with pytest.raises(ValidationError):
+            _make_log(initial_observation=blank)
+
+    def test_steps_without_llm_calls_aggregate_to_zero(self):
+        s1 = _make_step(step_index=1, reward=0.5)
+        s2 = _make_step(step_index=2, reward=0.5)
+        log = _make_log(steps=[s1, s2])
+        assert log.total_tokens == 0
+        assert log.total_cost_usd == 0.0
+
+
+# ===========================================================================
+# Outcome derivation
+# ===========================================================================
+
+
+class TestDeriveOutcome:
+    """Tests for _derive_outcome helper."""
+
+    def test_empty_steps(self):
+        assert _derive_outcome([]) is None
+
+    def test_success_from_reward(self):
+        step = _make_step(terminated=True, truncated=False, reward=1.0)
+        assert _derive_outcome([step]) == "success"
+
+    def test_failure_from_reward(self):
+        step = _make_step(terminated=True, truncated=False, reward=0.0)
+        assert _derive_outcome([step]) == "failure"
+
+    def test_negative_reward_failure(self):
+        step = _make_step(terminated=True, truncated=False, reward=-0.1)
+        assert _derive_outcome([step]) == "failure"
+
+    def test_truncated(self):
+        step = _make_step(terminated=False, truncated=True, reward=0.5)
+        assert _derive_outcome([step]) == "truncated"
+
+    def test_truncated_takes_precedence_over_terminated(self):
+        step = _make_step(terminated=True, truncated=True, reward=1.0)
+        assert _derive_outcome([step]) == "truncated"
+
+    def test_neither(self):
+        step = _make_step(terminated=False, truncated=False)
+        assert _derive_outcome([step]) is None
+
+    @pytest.mark.parametrize(
+        ("info_key", "info_val", "expected"),
+        [
+            ("correct", True, "success"),
+            ("correct", False, "failure"),
+            ("is_correct", True, "success"),
+            ("is_correct", False, "failure"),
+            ("success", True, "success"),
+            ("success", False, "failure"),
+            ("task_success", True, "success"),
+            ("task_success", False, "failure"),
+        ],
+    )
+    def test_info_key_takes_precedence(self, info_key, info_val, expected):
+        step = _make_step(
+            terminated=True,
+            truncated=False,
+            reward=0.0,
+            info={info_key: info_val},
+        )
+        assert _derive_outcome([step]) == expected
+
+    def test_info_correct_overrides_reward(self):
+        """GEM MathEnv returns correct=True with reward=1.0, but correct=False with reward=0.0.
+        The info key should be authoritative even if reward contradicts it."""
+        step = _make_step(
+            terminated=True,
+            truncated=False,
+            reward=1.0,
+            info={"correct": False},
+        )
+        assert _derive_outcome([step]) == "failure"
+
+    def test_info_key_not_present_falls_back_to_reward(self):
+        step = _make_step(
+            terminated=True,
+            truncated=False,
+            reward=1.0,
+            info={"suffix": "next"},
+        )
+        assert _derive_outcome([step]) == "success"
+
+    def test_info_truthy_int_value(self):
+        step = _make_step(terminated=True, truncated=False, reward=0.0, info={"correct": 1})
+        assert _derive_outcome([step]) == "success"
+
+    def test_info_true_overrides_negative_reward(self):
+        step = _make_step(terminated=True, truncated=False, reward=-1.0, info={"correct": True})
+        assert _derive_outcome([step]) == "success"
+
+
+# ===========================================================================
+# F1/F2: TrajectoryLogger Tests
+# ===========================================================================
 
 
 class TestTrajectoryLogger:
     """Tests for logger collection and persistence."""
 
     def test_save_writes_json_log(self, tmp_path):
-        """Test save persists a valid JSON trajectory in logs directory."""
         paths = ProjectPaths(root=tmp_path)
         logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy", seed=42)
         logger.set_initial_state("start", {"suffix": "next"})
@@ -139,7 +515,295 @@ class TestTrajectoryLogger:
         assert len(payload["steps"]) == 2
 
     def test_build_log_requires_initial_state(self):
-        """Test logger raises if reset state was never captured."""
         logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
         with pytest.raises(ValueError, match="initial state is not set"):
             logger.build_log()
+
+    def test_set_initial_state_cannot_be_called_twice(self):
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        logger.set_initial_state("first")
+        with pytest.raises(RuntimeError, match="already been set"):
+            logger.set_initial_state("second")
+
+    def test_system_prompt_stored(self):
+        logger = TrajectoryLogger(environment_id="math:Math12K")
+        logger.set_system_prompt("Solve step by step.")
+        logger.set_initial_state("What is 2+2?")
+        logger.add_step(
+            action="\\\\boxed{4}", observation="done", reward=1.0, terminated=True, truncated=False
+        )
+        log = logger.build_log()
+        assert log.system_prompt == "Solve step by step."
+
+    def test_build_log_schema_version(self):
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        logger.set_initial_state("start")
+        log = logger.build_log()
+        assert log.schema_version == SCHEMA_VERSION
+
+    def test_build_log_outcome_success(self):
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        logger.set_initial_state("start")
+        logger.add_step(action="a", observation="o", reward=1.0, terminated=True, truncated=False)
+        log = logger.build_log()
+        assert log.episode_outcome == "success"
+
+    def test_build_log_outcome_failure(self):
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        logger.set_initial_state("start")
+        logger.add_step(action="a", observation="o", reward=0.0, terminated=True, truncated=False)
+        log = logger.build_log()
+        assert log.episode_outcome == "failure"
+
+    def test_build_log_outcome_truncated(self):
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        logger.set_initial_state("start")
+        logger.add_step(action="a", observation="o", reward=0.5, terminated=False, truncated=True)
+        log = logger.build_log()
+        assert log.episode_outcome == "truncated"
+
+    def test_build_log_token_and_cost_aggregation(self):
+        logger = TrajectoryLogger(environment_id="math:Math12K")
+        logger.set_initial_state("problem")
+        logger.add_step(
+            action="a1",
+            observation="o1",
+            reward=0.0,
+            terminated=False,
+            truncated=False,
+            llm_call=_make_llm_call(10, 20, 0.01),
+        )
+        logger.add_step(
+            action="a2",
+            observation="o2",
+            reward=1.0,
+            terminated=True,
+            truncated=False,
+            llm_call=_make_llm_call(15, 25, 0.02),
+        )
+        log = logger.build_log()
+        assert log.total_tokens == 70
+        assert abs(log.total_cost_usd - 0.03) < 1e-9
+        assert log.num_steps == 2
+
+    def test_add_step_with_tool_calls(self):
+        logger = TrajectoryLogger(environment_id="code:CodeContest")
+        logger.set_initial_state("problem")
+        tc = ToolCall(
+            tool_name="python_exec",
+            tool_input="print(42)",
+            tool_output="42",
+            success=True,
+            duration_ms=100.0,
+        )
+        step = logger.add_step(
+            action="run code",
+            observation="output",
+            reward=1.0,
+            terminated=True,
+            truncated=False,
+            tool_calls=[tc],
+        )
+        assert len(step.tool_calls) == 1
+        assert step.tool_calls[0].tool_name == "python_exec"
+
+    def test_add_step_auto_timestamp(self):
+        logger = TrajectoryLogger(environment_id="math:Math12K")
+        logger.set_initial_state("start")
+        before = datetime.now(UTC)
+        step = logger.add_step(
+            action="a", observation="o", reward=0.0, terminated=False, truncated=False
+        )
+        after = datetime.now(UTC)
+        assert step.timestamp is not None
+        assert before <= step.timestamp <= after
+
+    def test_save_includes_new_fields(self, tmp_path):
+        paths = ProjectPaths(root=tmp_path)
+        logger = TrajectoryLogger(environment_id="math:Math12K", seed=1)
+        logger.set_system_prompt("Be precise.")
+        logger.set_initial_state("What is 1+1?")
+        logger.add_step(
+            action="\\\\boxed{2}",
+            observation="correct",
+            reward=1.0,
+            terminated=True,
+            truncated=False,
+            llm_call=_make_llm_call(5, 10, 0.005),
+        )
+        file_path = logger.save(project_paths=paths)
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+
+        assert payload["schema_version"] == SCHEMA_VERSION
+        assert payload["system_prompt"] == "Be precise."
+        assert payload["episode_outcome"] == "success"
+        assert payload["num_steps"] == 1
+        assert payload["total_tokens"] == 15
+        assert abs(payload["total_cost_usd"] - 0.005) < 1e-9
+
+    def test_save_failure_leaves_no_tmp_file(self, tmp_path):
+        logger = TrajectoryLogger(environment_id="game:GuessTheNumber-v0-easy")
+        paths = ProjectPaths(root=tmp_path)
+        with pytest.raises(ValueError, match="initial state is not set"):
+            logger.save(project_paths=paths)
+        tmp_files = list(tmp_path.rglob("*.tmp"))
+        assert tmp_files == []
+
+
+# ===========================================================================
+# F2: Trajectory Loading and Filtering Tests
+# ===========================================================================
+
+
+class TestTrajectoryLoadAndFilter:
+    """Tests for load_trajectory, load_all_trajectories, and filter_trajectories."""
+
+    def _save_log(self, tmp_path, logger: TrajectoryLogger, name: str) -> None:
+        paths = ProjectPaths(root=tmp_path)
+        log = logger.build_log()
+        file_path = paths.logs / f"trajectory_{name}_{log.run_id}.json"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(log.model_dump_json(indent=2), encoding="utf-8")
+
+    def test_load_nonexistent_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_trajectory(tmp_path / "does_not_exist.json")
+
+    def test_load_corrupt_json_raises(self, tmp_path):
+        bad_file = tmp_path / "trajectory_bad.json"
+        bad_file.write_text("{not valid json", encoding="utf-8")
+        with pytest.raises((json.JSONDecodeError, ValidationError)):
+            load_trajectory(bad_file)
+
+    def test_load_all_skips_corrupt_files(self, tmp_path):
+        paths = ProjectPaths(root=tmp_path)
+        paths.logs.mkdir(parents=True, exist_ok=True)
+
+        logger = TrajectoryLogger(environment_id="math:Math12K", seed=1)
+        logger.set_initial_state("problem")
+        logger.add_step(action="a", observation="o", reward=1.0, terminated=True, truncated=False)
+        logger.save(project_paths=paths)
+
+        (paths.logs / "trajectory_corrupt_badid.json").write_text("{not json", encoding="utf-8")
+        (paths.logs / "trajectory_empty_badid.json").write_text("", encoding="utf-8")
+
+        logs = load_all_trajectories(paths.logs)
+        assert len(logs) == 1
+        assert logs[0].environment_id == "math:Math12K"
+
+    def test_load_single_trajectory(self, tmp_path):
+        paths = ProjectPaths(root=tmp_path)
+        logger = TrajectoryLogger(environment_id="math:Math12K", seed=1)
+        logger.set_initial_state("problem")
+        logger.add_step(action="a", observation="o", reward=1.0, terminated=True, truncated=False)
+        file_path = logger.save(project_paths=paths)
+
+        loaded = load_trajectory(file_path)
+        assert loaded.environment_id == "math:Math12K"
+        assert loaded.total_reward == 1.0
+        assert loaded.num_steps == 1
+
+    def test_load_all_trajectories(self, tmp_path):
+        paths = ProjectPaths(root=tmp_path)
+        for i in range(3):
+            logger = TrajectoryLogger(environment_id="math:Math12K", seed=i)
+            logger.set_initial_state(f"problem_{i}")
+            logger.add_step(
+                action="a",
+                observation="o",
+                reward=float(i),
+                terminated=True,
+                truncated=False,
+            )
+            logger.save(project_paths=paths)
+
+        logs = load_all_trajectories(paths.logs)
+        assert len(logs) == 3
+        assert logs[0].started_at <= logs[1].started_at <= logs[2].started_at
+
+    def test_load_all_empty_directory(self, tmp_path):
+        paths = ProjectPaths(root=tmp_path)
+        logs = load_all_trajectories(paths.logs)
+        assert logs == []
+
+    def test_round_trip_serialization(self, tmp_path):
+        paths = ProjectPaths(root=tmp_path)
+        logger = TrajectoryLogger(environment_id="code:CodeContest", seed=42)
+        logger.set_system_prompt("Write efficient code.")
+        logger.set_initial_state("Implement fizzbuzz")
+        tc = ToolCall(
+            tool_name="python_exec",
+            tool_input="code",
+            tool_output="ok",
+            success=True,
+            duration_ms=50.0,
+        )
+        logger.add_step(
+            action="solution",
+            observation="passed",
+            reward=1.0,
+            terminated=True,
+            truncated=False,
+            tool_calls=[tc],
+            llm_call=_make_llm_call(20, 30, 0.02),
+        )
+        file_path = logger.save(project_paths=paths)
+
+        loaded = load_trajectory(file_path)
+        assert loaded.system_prompt == "Write efficient code."
+        assert loaded.episode_outcome == "success"
+        assert len(loaded.steps[0].tool_calls) == 1
+        assert loaded.steps[0].tool_calls[0].tool_name == "python_exec"
+        assert loaded.steps[0].llm_call is not None
+        assert loaded.steps[0].llm_call.total_tokens == 50
+
+    @pytest.mark.parametrize(
+        ("outcome", "expected_count"),
+        [
+            ("success", 2),
+            ("failure", 1),
+            ("truncated", 0),
+            (None, 3),
+        ],
+    )
+    def test_filter_by_outcome(self, outcome, expected_count):
+        now = datetime.now(UTC)
+        logs = [
+            _make_log(
+                environment_id="math:Math12K",
+                episode_outcome="success",
+                started_at=now,
+                finished_at=now + timedelta(seconds=1),
+            ),
+            _make_log(
+                environment_id="math:GSM8K",
+                episode_outcome="failure",
+                started_at=now,
+                finished_at=now + timedelta(seconds=1),
+            ),
+            _make_log(
+                environment_id="game:GuessTheNumber-v0-easy",
+                episode_outcome="success",
+                started_at=now,
+                finished_at=now + timedelta(seconds=1),
+            ),
+        ]
+
+        filtered = filter_trajectories(logs, outcome=outcome)
+        assert len(filtered) == expected_count
+
+    def test_filter_by_environment_id(self):
+        now = datetime.now(UTC)
+        logs = [
+            _make_log(
+                environment_id="math:Math12K",
+                started_at=now,
+                finished_at=now + timedelta(seconds=1),
+            ),
+            _make_log(
+                environment_id="math:GSM8K", started_at=now, finished_at=now + timedelta(seconds=1)
+            ),
+        ]
+        filtered = filter_trajectories(logs, environment_id="math:Math12K")
+        assert len(filtered) == 1
+        assert filtered[0].environment_id == "math:Math12K"


### PR DESCRIPTION
## Summary
- Extends `TrajectoryStep` with `ToolCall`, `LLMCallMetadata`, timestamps, and `info` dict for per-step instrumentation
- Adds `TrajectoryLog` fields: `schema_version`, `system_prompt`, `episode_outcome`, token/cost aggregates
- Implements `_derive_outcome()` using GEM info keys (e.g. `correct`, `is_correct`) with `reward > 0` fallback
- Adds `load_trajectory`, `load_all_trajectories`, `filter_trajectories` utilities with defensive error handling
- Atomic writes in `save()` via `os.replace()` for crash safety


## Related Issues

Closes #42, closes #43
Relates to #15

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [X] Test update
- [ ] Configuration change

## Changes Made

- `trajectory_logger.py`: Extended schema with `ToolCall`, `LLMCallMetadata`, `TrajectoryStep.timestamp`, `TrajectoryLog.system_prompt`, `episode_outcome`, `schema_version`, token/cost aggregates
- `trajectory_logger.py`: Added `_derive_outcome()` with GEM info key priority, `load_trajectory`, `load_all_trajectories` (with corrupt file skip), `filter_trajectories`
- `trajectory_logger.py`: Added `reject_non_finite_reward` validator, `set_initial_state` guard, atomic writes in `save()`
- `__init__.py`: Exported new models and utility functions
- `run_gem_episode.py`: Updated to use new schema fields, removed references to dropped `environment_type`
- `test_trajectory_logger.py`: 91 tests covering schema validation, outcome derivation, logger lifecycle, load/filter, and edge cases (inf/nan, corrupt files, blank strings, double-init guard)

## Testing

<!-- Describe how you tested these changes -->

- [X] Tests pass locally (`poe test`)
- [X] Linting passes (`poe lint`)
- [X] Type checking passes (`poe typecheck`)

### Test Commands Run

```bash
# List the commands you ran to test
poe test
```

## Checklist

<!-- Mark completed items with [x] -->

- [X] My code follows the project's code style guidelines
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix/feature works
- [X] New and existing tests pass locally
- [X] I have updated documentation if needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged

## Cost/Token Tracking (if applicable)

<!-- If this PR involves LLM calls, document the cost impact -->
N/A

| Metric | Value |
|--------|-------|
| Tokens used | |
| Estimated cost | |

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes
### Known limitations / Future work
- `llm_call` is singular per step; F3 (DSPy integration) may need `llm_calls: list[...]` for multi-forward scenarios
- Multi-turn conversation history not yet captured (planned for F3/adapter layer)
- No schema migration utility yet (only v1.0.0 exists)

<!-- Any additional context or notes for reviewers -->
