### PR TITLE
fix(adapters): add exponential backoff retry to LLM completion calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
-        run: uv run pytest --cov=src/trajectory_aware_gym --cov-report=xml -v
+        run: uv run pytest --cov=src/trajectory_aware_gym --cov-report=xml --cov-fail-under=85 -v
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,8 @@ repos:
           - boto3>=1.35.0
           - ddgs>=1.0.0
           - fastmcp>=2.0
+          - litellm>=1.50.0
+          - tenacity>=9.0.0
 
   # Security check - bandit
   - repo: https://github.com/PyCQA/bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,12 @@ addopts = [
     "--cov-report=html",
 ]
 
+[tool.coverage.run]
+source = ["src/trajectory_aware_gym"]
+
+[tool.coverage.report]
+fail_under = 85
+
 [tool.ruff]
 line-length = 100
 target-version = "py313"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pydantic-settings>=2.1.0",
     "PyYAML>=6.0",
     # Utilities
+    "tenacity>=9.0.0",
     "tqdm>=4.66.0",
     "rich>=13.7.0",
     "click>=8.3.1",

--- a/src/trajectory_aware_gym/adapters/gem_episode_runner.py
+++ b/src/trajectory_aware_gym/adapters/gem_episode_runner.py
@@ -4,11 +4,32 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from litellm import completion, completion_cost  # type: ignore[import-untyped]
+from litellm.exceptions import (  # type: ignore[import-untyped]
+    APIConnectionError as LiteLLMConnectionError,
+)
+from litellm.exceptions import (
+    InternalServerError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
+from litellm.exceptions import (
+    Timeout as LiteLLMTimeout,
+)
+from tenacity import (
+    Retrying,
+    before_sleep_log,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_exponential_jitter,
+)
 
 from trajectory_aware_gym.adapters.tool_runtime import ToolRuntime
 from trajectory_aware_gym.adapters.trajectory_logger import (
@@ -21,6 +42,8 @@ from trajectory_aware_gym.adapters.trajectory_logger import (
 from trajectory_aware_gym.config import settings
 from trajectory_aware_gym.metrics import EpisodeRawMetrics, extract_episode_raw_metrics
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_MAX_RESPONSE_TOKENS = 4096
 DEFAULT_MAX_TOOL_ROUNDS = 3
 TERMINAL_OBSERVATION = "<TERMINAL>"
@@ -30,6 +53,77 @@ type ChatMessage = dict[str, str]
 _TOOL_NAME_ALIASES = {
     "web_search": "search",
 }
+
+# LiteLLM exception types that indicate transient, retryable failures.
+_RETRYABLE_EXCEPTIONS = (
+    RateLimitError,  # 429 — throttling
+    ServiceUnavailableError,  # 503 — capacity pressure
+    InternalServerError,  # 500 — transient server error
+    LiteLLMTimeout,  # request timeout
+    LiteLLMConnectionError,  # connection-level failures
+)
+
+# ── Inference concurrency semaphore ─────────────────────────────
+_inference_semaphore: threading.Semaphore | None = None
+_semaphore_lock = threading.Lock()
+
+
+def _get_inference_semaphore() -> threading.Semaphore:
+    """Lazily initialise the inference semaphore from ``settings.retry``."""
+    global _inference_semaphore  # noqa: PLW0603
+    if _inference_semaphore is None:
+        with _semaphore_lock:
+            if _inference_semaphore is None:
+                _inference_semaphore = threading.Semaphore(settings.retry.inference_semaphore_size)
+    return _inference_semaphore
+
+
+def _reset_inference_semaphore() -> None:
+    """Reset the module-level semaphore (for test isolation)."""
+    global _inference_semaphore  # noqa: PLW0603
+    _inference_semaphore = None
+
+
+def _completion_with_retry(
+    *,
+    messages: list[ChatMessage],
+    completion_kwargs: dict[str, Any],
+) -> Any:
+    """Call ``litellm.completion()`` with tenacity retry on transient errors.
+
+    Retry parameters are read from ``settings.retry`` at call time so that
+    tests can override them via monkeypatch.
+    """
+    retry_cfg = settings.retry
+
+    if retry_cfg.jitter:
+        wait_strategy = wait_exponential_jitter(
+            initial=retry_cfg.initial_wait_seconds,
+            max=retry_cfg.max_wait_seconds,
+            exp_base=retry_cfg.exponential_base,
+        )
+    else:
+        wait_strategy = wait_exponential(
+            min=retry_cfg.initial_wait_seconds,
+            max=retry_cfg.max_wait_seconds,
+            exp_base=retry_cfg.exponential_base,
+        )
+
+    retryer = Retrying(
+        stop=stop_after_attempt(retry_cfg.max_attempts),
+        wait=wait_strategy,
+        retry=retry_if_exception_type(_RETRYABLE_EXCEPTIONS),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+
+    completion_kwargs["num_retries"] = retry_cfg.litellm_num_retries
+
+    semaphore = _get_inference_semaphore()
+    for attempt in retryer:
+        with attempt:
+            with semaphore:
+                return completion(messages=messages, **completion_kwargs)
 
 
 @dataclass(frozen=True)
@@ -128,9 +222,9 @@ def generate_smoke_action(
     if model_id.startswith("bedrock/"):
         settings.validate_aws()
 
-    response = completion(
+    response = _completion_with_retry(
         messages=messages,
-        **_build_completion_kwargs(
+        completion_kwargs=_build_completion_kwargs(
             model_id,
             temperature=temperature,
             max_tokens=max_tokens,

--- a/src/trajectory_aware_gym/config/__init__.py
+++ b/src/trajectory_aware_gym/config/__init__.py
@@ -9,6 +9,7 @@ from trajectory_aware_gym.config.core import (
     GEPAModel,
     LoggingModel,
     OllamaModel,
+    RetryModel,
     SageMakerModel,
     Settings,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "LoggingModel",
     "OllamaModel",
     "ProjectPaths",
+    "RetryModel",
     "SageMakerModel",
     "Settings",
     "settings",

--- a/src/trajectory_aware_gym/config/core.py
+++ b/src/trajectory_aware_gym/config/core.py
@@ -120,6 +120,26 @@ class CostTrackingModel(BaseModel):
     alert_threshold: float
 
 
+class RetryModel(BaseModel):
+    """Retry, backoff, and concurrency throttling for LLM inference."""
+
+    max_attempts: int = Field(
+        default=4, ge=1, description="Total attempts including initial (1 = no retry)"
+    )
+    initial_wait_seconds: float = Field(default=1.0, ge=0.1)
+    max_wait_seconds: float = Field(default=30.0, ge=1.0)
+    exponential_base: float = Field(default=2.0, ge=1.1)
+    jitter: bool = Field(default=True, description="Add random jitter to backoff wait times")
+    litellm_num_retries: int = Field(
+        default=0, ge=0, description="LiteLLM internal retries (0 avoids stacking)"
+    )
+    boto3_retry_mode: str = Field(default="standard")
+    boto3_max_attempts: int = Field(default=3, ge=1)
+    inference_semaphore_size: int = Field(
+        default=4, ge=1, description="Max concurrent inflight LLM calls"
+    )
+
+
 class FitnessModel(BaseModel):
     """Hyperparameters for trajectory-aware fitness computation."""
 
@@ -145,6 +165,7 @@ _SECTION_MAP: list[tuple[str, str, type[BaseModel]]] = [
     ("logging", "LOG", LoggingModel),
     ("cost_tracking", "COST_TRACKING", CostTrackingModel),
     ("fitness", "FITNESS", FitnessModel),
+    ("retry", "RETRY", RetryModel),
 ]
 
 
@@ -167,6 +188,7 @@ class Settings:
     _logging: LoggingModel
     _cost_tracking: CostTrackingModel
     _fitness: FitnessModel
+    _retry: RetryModel
 
     def __init__(self, yaml_path: Path | None = None) -> None:
         if not Settings._loaded:
@@ -245,6 +267,10 @@ class Settings:
     @property
     def fitness(self) -> FitnessModel:
         return self._fitness
+
+    @property
+    def retry(self) -> RetryModel:
+        return self._retry
 
     @classmethod
     @contextmanager

--- a/src/trajectory_aware_gym/config/core.py
+++ b/src/trajectory_aware_gym/config/core.py
@@ -123,21 +123,16 @@ class CostTrackingModel(BaseModel):
 class RetryModel(BaseModel):
     """Retry, backoff, and concurrency throttling for LLM inference."""
 
-    max_attempts: int = Field(
-        default=4, ge=1, description="Total attempts including initial (1 = no retry)"
-    )
-    initial_wait_seconds: float = Field(default=1.0, ge=0.1)
-    max_wait_seconds: float = Field(default=30.0, ge=1.0)
-    exponential_base: float = Field(default=2.0, ge=1.1)
-    jitter: bool = Field(default=True, description="Add random jitter to backoff wait times")
-    litellm_num_retries: int = Field(
-        default=0, ge=0, description="LiteLLM internal retries (0 avoids stacking)"
-    )
-    boto3_retry_mode: str = Field(default="standard")
-    boto3_max_attempts: int = Field(default=3, ge=1)
-    inference_semaphore_size: int = Field(
-        default=4, ge=1, description="Max concurrent inflight LLM calls"
-    )
+    max_attempts: int = Field(ge=1)
+    initial_wait_seconds: float = Field(ge=0.1)
+    max_wait_seconds: float = Field(ge=1.0)
+    exponential_base: float = Field(ge=1.1)
+    jitter: bool
+    litellm_num_retries: int = Field(ge=0)
+    boto3_retry_mode: str
+    boto3_max_attempts: int = Field(ge=1)
+    sagemaker_read_timeout_seconds: int = Field(ge=10)
+    inference_semaphore_size: int = Field(ge=1)
 
 
 class FitnessModel(BaseModel):

--- a/src/trajectory_aware_gym/config/trajectory-aware-gym.yaml
+++ b/src/trajectory_aware_gym/config/trajectory-aware-gym.yaml
@@ -71,4 +71,4 @@ retry:
   boto3_retry_mode: standard
   boto3_max_attempts: 3
   sagemaker_read_timeout_seconds: 90
-  inference_semaphore_size: 4
+  inference_semaphore_size: 16

--- a/src/trajectory_aware_gym/config/trajectory-aware-gym.yaml
+++ b/src/trajectory_aware_gym/config/trajectory-aware-gym.yaml
@@ -70,4 +70,5 @@ retry:
   litellm_num_retries: 0
   boto3_retry_mode: standard
   boto3_max_attempts: 3
+  sagemaker_read_timeout_seconds: 90
   inference_semaphore_size: 4

--- a/src/trajectory_aware_gym/config/trajectory-aware-gym.yaml
+++ b/src/trajectory_aware_gym/config/trajectory-aware-gym.yaml
@@ -60,3 +60,14 @@ logging:
 cost_tracking:
   enabled: true
   alert_threshold: 100.0
+
+retry:
+  max_attempts: 4
+  initial_wait_seconds: 1.0
+  max_wait_seconds: 30.0
+  exponential_base: 2.0
+  jitter: true
+  litellm_num_retries: 0
+  boto3_retry_mode: standard
+  boto3_max_attempts: 3
+  inference_semaphore_size: 4

--- a/src/trajectory_aware_gym/sagemaker/client.py
+++ b/src/trajectory_aware_gym/sagemaker/client.py
@@ -19,17 +19,42 @@ CLI::
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
+from botocore.config import Config as BotocoreConfig
+from botocore.exceptions import ClientError
+from tenacity import (
+    Retrying,
+    before_sleep_log,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from trajectory_aware_gym.config import settings
+
+logger = logging.getLogger(__name__)
 
 ENDPOINTS: dict[str, str] = {
     "1.7b": settings.sagemaker.endpoint_1_7b,
     "4b": settings.sagemaker.endpoint_4b,
 }
+
+_RETRYABLE_SAGEMAKER_STATUS_CODES = (424, 429, 503)
+_RETRYABLE_SAGEMAKER_ERROR_CODES = ("ModelError", "ThrottlingException")
+
+
+def _is_retryable_sagemaker_error(exc: BaseException) -> bool:
+    """Check if a botocore ``ClientError`` is retryable for SageMaker endpoints."""
+    if not isinstance(exc, ClientError):
+        return False
+    error_info = exc.response.get("Error", {})
+    code = error_info.get("Code", "")
+    status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+    return status in _RETRYABLE_SAGEMAKER_STATUS_CODES or code in _RETRYABLE_SAGEMAKER_ERROR_CODES
 
 
 class QwenClient:
@@ -41,9 +66,20 @@ class QwenClient:
 
         self.model = model
         self.endpoint_name = ENDPOINTS[model]
+
+        retry_cfg = settings.retry
+        boto_config = BotocoreConfig(
+            retries={
+                "mode": retry_cfg.boto3_retry_mode,
+                "total_max_attempts": retry_cfg.boto3_max_attempts,
+            },
+            max_pool_connections=retry_cfg.inference_semaphore_size + 2,
+            read_timeout=90,
+        )
         self.client = boto3.client(
             "sagemaker-runtime",
             region_name=region or settings.sagemaker.region,
+            config=boto_config,
         )
 
     def generate(
@@ -77,13 +113,28 @@ class QwenClient:
             },
         }
 
-        response = self.client.invoke_endpoint(
-            EndpointName=self.endpoint_name,
-            ContentType="application/json",
-            Body=json.dumps(payload),
+        retry_cfg = settings.retry
+        retryer = Retrying(
+            stop=stop_after_attempt(retry_cfg.max_attempts),
+            wait=wait_exponential_jitter(
+                initial=retry_cfg.initial_wait_seconds,
+                max=retry_cfg.max_wait_seconds,
+                exp_base=retry_cfg.exponential_base,
+            ),
+            retry=retry_if_exception(_is_retryable_sagemaker_error),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
         )
 
-        result = json.loads(response["Body"].read().decode())
+        for attempt in retryer:
+            with attempt:
+                response = self.client.invoke_endpoint(
+                    EndpointName=self.endpoint_name,
+                    ContentType="application/json",
+                    Body=json.dumps(payload),
+                )
+
+        result = json.loads(response["Body"].read().decode())  # type: ignore[possibly-undefined]
 
         if isinstance(result, list):
             return result[0].get("generated_text", "")

--- a/src/trajectory_aware_gym/sagemaker/client.py
+++ b/src/trajectory_aware_gym/sagemaker/client.py
@@ -46,6 +46,10 @@ ENDPOINTS: dict[str, str] = {
 _RETRYABLE_SAGEMAKER_STATUS_CODES = (424, 429, 503)
 _RETRYABLE_SAGEMAKER_ERROR_CODES = ("ModelError", "ThrottlingException")
 
+# Extra connections beyond the semaphore size so that retries in flight
+# don't block behind the pool while the original slot is still draining.
+_POOL_CONNECTION_HEADROOM = 2
+
 
 def _is_retryable_sagemaker_error(exc: BaseException) -> bool:
     """Check if a botocore ``ClientError`` is retryable for SageMaker endpoints."""
@@ -73,8 +77,8 @@ class QwenClient:
                 "mode": retry_cfg.boto3_retry_mode,
                 "total_max_attempts": retry_cfg.boto3_max_attempts,
             },
-            max_pool_connections=retry_cfg.inference_semaphore_size + 2,
-            read_timeout=90,
+            max_pool_connections=retry_cfg.inference_semaphore_size + _POOL_CONNECTION_HEADROOM,
+            read_timeout=retry_cfg.sagemaker_read_timeout_seconds,
         )
         self.client = boto3.client(
             "sagemaker-runtime",
@@ -133,12 +137,12 @@ class QwenClient:
                     ContentType="application/json",
                     Body=json.dumps(payload),
                 )
+                result = json.loads(response["Body"].read().decode())
+                if isinstance(result, list):
+                    return result[0].get("generated_text", "")
+                return result.get("generated_text", "")
 
-        result = json.loads(response["Body"].read().decode())  # type: ignore[possibly-undefined]
-
-        if isinstance(result, list):
-            return result[0].get("generated_text", "")
-        return result.get("generated_text", "")
+        raise RuntimeError("Retry loop exited without returning")
 
     def generate_batch(
         self,

--- a/src/trajectory_aware_gym/storage/trajectory_db.py
+++ b/src/trajectory_aware_gym/storage/trajectory_db.py
@@ -141,10 +141,13 @@ def get_connection(db_path: Path) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path), timeout=_SQLITE_CONNECT_TIMEOUT_SECONDS)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
     with _initialized_dbs_lock:
         if key not in _initialized_dbs:
+            # journal_mode is persistent on the db file — set once during init.
+            # Setting it outside the lock races with executescript's EXCLUSIVE
+            # lock on slow CI runners.
+            conn.execute("PRAGMA journal_mode=WAL")
             conn.executescript(_SCHEMA_SQL)
             _initialized_dbs.add(key)
     connections[key] = conn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 
+from trajectory_aware_gym.adapters.gem_episode_runner import _reset_inference_semaphore
 from trajectory_aware_gym.config.core import Settings
 
 _CONFIG_ENV_PREFIXES = (
@@ -17,6 +18,7 @@ _CONFIG_ENV_PREFIXES = (
     "FITNESS_",
     "LOG_",
     "COST_TRACKING_",
+    "RETRY_",
 )
 
 
@@ -30,8 +32,10 @@ def _reset_settings(monkeypatch):
     override specific values.
     """
     Settings.reset()
+    _reset_inference_semaphore()
     for key in list(os.environ.keys()):
         if any(key.startswith(prefix) for prefix in _CONFIG_ENV_PREFIXES):
             monkeypatch.delenv(key, raising=False)
     yield
     Settings.reset()
+    _reset_inference_semaphore()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -103,7 +103,7 @@ class TestSettingsLoad:
         assert s.retry.boto3_retry_mode == "standard"
         assert s.retry.boto3_max_attempts == 3
         assert s.retry.sagemaker_read_timeout_seconds == 90
-        assert s.retry.inference_semaphore_size == 4
+        assert s.retry.inference_semaphore_size == 16
 
     def test_missing_yaml_raises_on_required_fields(self, tmp_path):
         empty_yaml = tmp_path / "empty.yaml"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,6 +11,7 @@ from trajectory_aware_gym.config.core import (
     AWSModel,
     GEMModel,
     GEPAModel,
+    RetryModel,
     Settings,
     _coerce,
     _with_env_overrides,
@@ -91,6 +92,18 @@ class TestSettingsLoad:
         assert s.fitness.max_steps == 50
         assert s.fitness.loop_window == 3
 
+    def test_loads_retry_section(self):
+        s = _load_settings()
+        assert s.retry.max_attempts == 4
+        assert s.retry.initial_wait_seconds == 1.0
+        assert s.retry.max_wait_seconds == 30.0
+        assert s.retry.exponential_base == 2.0
+        assert s.retry.jitter is True
+        assert s.retry.litellm_num_retries == 0
+        assert s.retry.boto3_retry_mode == "standard"
+        assert s.retry.boto3_max_attempts == 3
+        assert s.retry.inference_semaphore_size == 4
+
     def test_missing_yaml_raises_on_required_fields(self, tmp_path):
         empty_yaml = tmp_path / "empty.yaml"
         empty_yaml.write_text("")
@@ -147,6 +160,16 @@ class TestEnvVarOverrides:
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
         s = _load_settings()
         assert s.aws.access_key_id == "AKIATEST"
+
+    def test_env_overrides_retry_int_field(self, monkeypatch):
+        monkeypatch.setenv("RETRY_MAX_ATTEMPTS", "6")
+        s = _load_settings()
+        assert s.retry.max_attempts == 6
+
+    def test_env_overrides_retry_float_field(self, monkeypatch):
+        monkeypatch.setenv("RETRY_INITIAL_WAIT_SECONDS", "2.5")
+        s = _load_settings()
+        assert s.retry.initial_wait_seconds == 2.5
 
     def test_yaml_value_used_when_env_absent(self):
         assert os.getenv("GEM_MAX_STEPS") is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -102,6 +102,7 @@ class TestSettingsLoad:
         assert s.retry.litellm_num_retries == 0
         assert s.retry.boto3_retry_mode == "standard"
         assert s.retry.boto3_max_attempts == 3
+        assert s.retry.sagemaker_read_timeout_seconds == 90
         assert s.retry.inference_semaphore_size == 4
 
     def test_missing_yaml_raises_on_required_fields(self, tmp_path):

--- a/tests/unit/test_experiment_runner.py
+++ b/tests/unit/test_experiment_runner.py
@@ -674,7 +674,8 @@ def test_run_heldout_eval_rollouts_and_summary(monkeypatch: pytest.MonkeyPatch) 
     assert summary["success_rate"] == pytest.approx(0.5)
     assert summary["correct"] == 2
     assert summary["accuracy"] == pytest.approx(0.5)
-    assert run_calls == [
+    # ThreadPoolExecutor order is non-deterministic; sort by episode_index.
+    assert sorted(run_calls) == [
         (0, 100, "p1"),
         (1, 101, None),
         (2, 200, "p2"),

--- a/tests/unit/test_gem_episode_runner.py
+++ b/tests/unit/test_gem_episode_runner.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from litellm.exceptions import ServiceUnavailableError  # type: ignore[import-untyped]
 
-from trajectory_aware_gym.adapters.gem_episode_runner import GEMEpisodeRunner
+from trajectory_aware_gym.adapters.gem_episode_runner import (
+    GEMEpisodeRunner,
+    _reset_inference_semaphore,
+)
+from trajectory_aware_gym.config.core import Settings
 
 
 class _FakeGemModule:
@@ -208,3 +214,64 @@ def test_runner_tracks_episode_history(monkeypatch):
 
     runner.clear_episode_history()
     assert runner.episode_history == ()
+
+
+def test_run_episode_retries_transient_completion_error(monkeypatch):
+    """generate_smoke_action() retries on transient LiteLLM errors."""
+
+    # Fast retry waits for test speed
+    Settings.reset()
+    _reset_inference_semaphore()
+    s = Settings()
+    monkeypatch.setattr(s.retry, "initial_wait_seconds", 0.01)
+    monkeypatch.setattr(s.retry, "max_wait_seconds", 0.05)
+    monkeypatch.setattr(s.retry, "max_attempts", 3)
+
+    class FakeEnv:
+        def reset(self, **kwargs: Any) -> tuple[str, dict[str, str]]:
+            return "Solve 2 + 2", {"source": "unit"}
+
+        def step(self, action: str) -> tuple[str, float, bool, bool, dict[str, bool]]:
+            return "Correct", 1.0, True, False, {"correct": True}
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
+        _fake_import_module_factory(FakeEnv()),
+    )
+
+    calls: list[int] = []
+
+    def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+        calls.append(1)
+        if len(calls) == 1:
+            raise ServiceUnavailableError(
+                message="503 Service Unavailable",
+                llm_provider="bedrock",
+                model="test-model",
+            )
+        return _make_response("\\boxed{4}")
+
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+        mock_completion,
+    )
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.completion_cost",
+        lambda *, completion_response: 0.01,
+    )
+
+    runner = GEMEpisodeRunner(
+        environment_id="math:Orz57K",
+        model_id="ollama/qwen3-1.7b-base",
+        temperature=0.0,
+        max_steps=3,
+        seed=42,
+    )
+
+    result = runner.run_episode("Solve carefully.", persist=False)
+    assert len(calls) == 2
+    assert result.trajectory.total_reward == 1.0
+    assert result.raw_metrics.success is True

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,250 @@
+"""Tests for exponential backoff retry and concurrency semaphore."""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from litellm.exceptions import (  # type: ignore[import-untyped]
+    AuthenticationError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
+
+from trajectory_aware_gym.adapters.gem_episode_runner import (
+    _completion_with_retry,
+    _reset_inference_semaphore,
+)
+from trajectory_aware_gym.config.core import Settings
+
+
+def _make_response(text: str = "answer") -> SimpleNamespace:
+    usage = SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8)
+    message = SimpleNamespace(content=text, reasoning_content=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=usage)
+
+
+def _fast_retry_settings(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> None:
+    """Load settings with fast retry waits for tests."""
+    Settings.reset()
+    _reset_inference_semaphore()
+    s = Settings()
+    monkeypatch.setattr(
+        s.retry, "initial_wait_seconds", overrides.get("initial_wait_seconds", 0.01)
+    )
+    monkeypatch.setattr(s.retry, "max_wait_seconds", overrides.get("max_wait_seconds", 0.05))
+    for key, value in overrides.items():
+        if key not in ("initial_wait_seconds", "max_wait_seconds"):
+            monkeypatch.setattr(s.retry, key, value)
+
+
+# ===========================================================================
+# Retry on transient errors
+# ===========================================================================
+
+
+class TestCompletionWithRetry:
+    """Tests for _completion_with_retry() tenacity wrapper."""
+
+    def test_succeeds_after_transient_error(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, max_attempts=3)
+        calls: list[dict[str, Any]] = []
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise ServiceUnavailableError(
+                    message="503 Service Unavailable",
+                    llm_provider="bedrock",
+                    model="test-model",
+                )
+            return _make_response()
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        result = _completion_with_retry(
+            messages=[{"role": "user", "content": "test"}],
+            completion_kwargs={"model": "bedrock/test"},
+        )
+        assert len(calls) == 2
+        assert result.choices[0].message.content == "answer"
+
+    def test_exhausted_retries_reraise_original(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, max_attempts=3)
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            raise RateLimitError(
+                message="429 Rate Limit",
+                llm_provider="bedrock",
+                model="test-model",
+            )
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        with pytest.raises(RateLimitError, match="429"):
+            _completion_with_retry(
+                messages=[{"role": "user", "content": "test"}],
+                completion_kwargs={"model": "bedrock/test"},
+            )
+
+    def test_non_retryable_exception_propagates_immediately(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, max_attempts=3)
+        calls: list[int] = []
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            calls.append(1)
+            raise AuthenticationError(
+                message="403 Forbidden",
+                llm_provider="bedrock",
+                model="test-model",
+            )
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        with pytest.raises(AuthenticationError, match="403"):
+            _completion_with_retry(
+                messages=[{"role": "user", "content": "test"}],
+                completion_kwargs={"model": "bedrock/test"},
+            )
+
+        assert len(calls) == 1
+
+    def test_injects_litellm_num_retries_zero(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, litellm_num_retries=0)
+        captured_kwargs: dict[str, Any] = {}
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            captured_kwargs.update(kwargs)
+            return _make_response()
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        _completion_with_retry(
+            messages=[{"role": "user", "content": "test"}],
+            completion_kwargs={"model": "bedrock/test"},
+        )
+        assert captured_kwargs["num_retries"] == 0
+
+    def test_no_retry_when_max_attempts_is_one(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, max_attempts=1)
+        calls: list[int] = []
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            calls.append(1)
+            raise ServiceUnavailableError(
+                message="503",
+                llm_provider="bedrock",
+                model="test-model",
+            )
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        with pytest.raises(ServiceUnavailableError):
+            _completion_with_retry(
+                messages=[{"role": "user", "content": "test"}],
+                completion_kwargs={"model": "bedrock/test"},
+            )
+        assert len(calls) == 1
+
+    def test_uses_exponential_backoff_without_jitter(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, max_attempts=2, jitter=False)
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            if not hasattr(mock_completion, "_called"):
+                mock_completion._called = True  # type: ignore[attr-defined]
+                raise ServiceUnavailableError(
+                    message="503",
+                    llm_provider="bedrock",
+                    model="test-model",
+                )
+            return _make_response()
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        result = _completion_with_retry(
+            messages=[{"role": "user", "content": "test"}],
+            completion_kwargs={"model": "bedrock/test"},
+        )
+        assert result.choices[0].message.content == "answer"
+
+
+# ===========================================================================
+# Semaphore concurrency tests
+# ===========================================================================
+
+
+class TestInferenceSemaphore:
+    """Tests that the semaphore caps concurrent inflight LLM calls."""
+
+    def test_semaphore_limits_concurrency(self, monkeypatch):
+        _fast_retry_settings(monkeypatch, inference_semaphore_size=2)
+        _reset_inference_semaphore()
+
+        max_concurrent = 0
+        current_concurrent = 0
+        lock = threading.Lock()
+
+        def mock_completion(messages: Any, **kwargs: Any) -> SimpleNamespace:
+            nonlocal max_concurrent, current_concurrent
+            with lock:
+                current_concurrent += 1
+                if current_concurrent > max_concurrent:
+                    max_concurrent = current_concurrent
+
+            # Give other threads a chance to enter
+            time.sleep(0.05)
+
+            with lock:
+                current_concurrent -= 1
+
+            return _make_response()
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            mock_completion,
+        )
+
+        results: list[Any] = [None] * 4
+        errors: list[Exception] = []
+
+        def worker(idx: int) -> None:
+            try:
+                results[idx] = _completion_with_retry(
+                    messages=[{"role": "user", "content": f"test-{idx}"}],
+                    completion_kwargs={"model": "bedrock/test"},
+                )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Worker threads raised: {errors}"
+        assert all(r is not None for r in results)
+        # With semaphore_size=2, at most 2 should be concurrent
+        assert max_concurrent <= 2

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -6,7 +6,6 @@ import threading
 import time
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from litellm.exceptions import (  # type: ignore[import-untyped]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1284,7 +1284,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1293,7 +1292,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1302,7 +1300,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -4622,6 +4619,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "scipy" },
+    { name = "tenacity" },
     { name = "tqdm" },
 ]
 
@@ -4667,6 +4665,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "scipy", specifier = ">=1.12.0" },
+    { name = "tenacity", specifier = ">=9.0.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Add tenacity-based exponential backoff retry to `generate_smoke_action()` and `QwenClient.generate()` to handle transient SageMaker 424, Bedrock 503, and rate limit errors
- Add configurable `RetryModel` to infrastructure config with tunable backoff params, jitter, and concurrency semaphore
- Add module-level inference semaphore to cap concurrent LLM calls, preventing endpoint overload from parallel eval workers

## Related Issues

Closes #147

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update
- [x] Configuration change

## Changes Made

- **`src/trajectory_aware_gym/config/core.py`**: Added `RetryModel` with 9 fields (max_attempts, initial_wait_seconds, max_wait_seconds, exponential_base, jitter, litellm_num_retries, boto3_retry_mode, boto3_max_attempts, inference_semaphore_size)
- **`src/trajectory_aware_gym/adapters/gem_episode_runner.py`**: Added `_completion_with_retry()` wrapping only the `litellm.completion()` call with tenacity retry on transient LiteLLM exceptions. Added lazy-init inference semaphore to cap concurrent inflight LLM calls. LiteLLM internal retry disabled (`num_retries=0`) to avoid stacking with tenacity.
- **`src/trajectory_aware_gym/sagemaker/client.py`**: Added `botocore.config.Config` with standard retry mode, connection pool sizing, and 90s read timeout. Added tenacity retry on `invoke_endpoint()` for SageMaker 424/429/503 errors.
- **`pyproject.toml`**: Added explicit `tenacity>=9.0.0` dependency
- **`.pre-commit-config.yaml`**: Added `litellm` and `tenacity` to pyright hook's `additional_dependencies`
- **`tests/unit/test_retry.py`**: New file with 7 tests covering transient retry, exhaustion, non-retryable propagation, `num_retries=0` injection, no-retry mode, jitter-off path, and semaphore concurrency limiting

### Retry layer coordination

| Layer | Retries | Scope |
|-------|---------|-------|
| **tenacity** (our code) | 4 total attempts | All LiteLLM + QwenClient calls |
| **LiteLLM** | Disabled (0) | n/a — avoids stacking |
| **botocore** (QwenClient only) | 3 attempts, standard mode | AWS SDK-level errors |

## Testing

- [x] Tests pass locally (`poe test`) — 597 passed
- [x] Linting passes (`poe lint`)
- [x] Type checking passes (`poe typecheck`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)

### Test Commands Run

```bash
poe test           # 597 passed
poe lint           # All checks passed
poe typecheck      # 0 errors, 0 warnings
uv run pre-commit run --all-files  # 14/14 hooks passed
```

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Cost/Token Tracking (if applicable)

N/A — retry infrastructure only; no LLM calls made.

## Additional Notes

- Default `inference_semaphore_size=4` is tuned for a single-GPU `ml.g5.xlarge`. Adjust via `RETRY_INFERENCE_SEMAPHORE_SIZE` env var for multi-GPU endpoints.
- All retry config is overridable via env vars with `RETRY_` prefix (e.g., `RETRY_MAX_ATTEMPTS=6`).