### PR TITLE
feat(sampling): align task-model sampling with GEM paper and cache HF datasets

### DIFF
--- a/src/trajectory_aware_gym/adapters/gem_env_factory.py
+++ b/src/trajectory_aware_gym/adapters/gem_env_factory.py
@@ -1,0 +1,80 @@
+"""Factory for GEM environments that caches HF datasets across instantiations.
+
+``gem.make(env_id)`` calls ``datasets.load_dataset(dataset_name)`` inside the
+env constructor, which sends HEAD requests to Hugging Face even when the
+dataset is already cached locally. With hundreds of eval/GEPA rollouts, that
+floods the HF endpoint and triggers HTTP 429 rate limits.
+
+This module resolves the ``dataset_name`` from GEM's ``ENV_REGISTRY`` entry,
+loads the dataset exactly once per env_id (thread-safe), and passes the cached
+object to ``gem.make()`` via the ``dataset=`` kwarg that ``MathEnv`` / ``QaEnv``
+/ ``CodeEnv`` / ``MathVisualEnv`` all accept.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from typing import Any
+
+_dataset_cache: dict[str, Any] = {}
+_cache_lock = threading.Lock()
+
+
+def _load_env_dataset(env_id: str) -> Any | None:
+    """Return a cached dataset for ``env_id`` or ``None`` if the env has none.
+
+    Looks up ``env_id`` in GEM's registry, pulls the ``dataset_name`` kwarg,
+    and calls ``datasets.load_dataset`` once per env_id. Envs without a
+    ``dataset_name`` (game envs, reasoning_gym) return ``None``.
+    """
+    if env_id in _dataset_cache:
+        return _dataset_cache[env_id]
+
+    with _cache_lock:
+        if env_id in _dataset_cache:
+            return _dataset_cache[env_id]
+
+        importlib.import_module("gem.envs")
+        registration = importlib.import_module("gem.envs.registration")
+        registry: dict[str, Any] = registration.ENV_REGISTRY
+        spec = registry.get(env_id)
+        if spec is None:
+            _dataset_cache[env_id] = None
+            return None
+
+        dataset_name = spec.kwargs.get("dataset_name")
+        if not dataset_name:
+            _dataset_cache[env_id] = None
+            return None
+
+        from datasets import load_dataset  # pyright: ignore[reportMissingImports]
+
+        # GEM itself registers datasets by name only and loads them without
+        # revision pinning. Pinning here would be asymmetric with the
+        # underlying library and does not reduce the attack surface.
+        _dataset_cache[env_id] = load_dataset(dataset_name)  # nosec B615
+        return _dataset_cache[env_id]
+
+
+def make_env(env_id: str, **kwargs: Any) -> Any:
+    """Construct a GEM env, reusing a process-wide cached HF dataset.
+
+    Falls back to plain ``gem.make(env_id, **kwargs)`` for envs that don't
+    use a Hugging Face dataset or when the caller has already supplied a
+    ``dataset=`` override.
+    """
+    gem = importlib.import_module("gem")
+
+    if "dataset" not in kwargs:
+        cached = _load_env_dataset(env_id)
+        if cached is not None:
+            kwargs["dataset"] = cached
+
+    return gem.make(env_id, **kwargs)
+
+
+def reset_dataset_cache() -> None:
+    """Clear the cache (for test isolation)."""
+    with _cache_lock:
+        _dataset_cache.clear()

--- a/src/trajectory_aware_gym/adapters/gem_episode_runner.py
+++ b/src/trajectory_aware_gym/adapters/gem_episode_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 import logging
 import math
@@ -33,6 +32,7 @@ from tenacity import (  # pyright: ignore[reportMissingImports]
     wait_exponential_jitter,
 )
 
+from trajectory_aware_gym.adapters.gem_env_factory import make_env
 from trajectory_aware_gym.adapters.tool_runtime import ToolRuntime
 from trajectory_aware_gym.adapters.trajectory_logger import (
     LLMCallMetadata,
@@ -49,6 +49,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_RESPONSE_TOKENS = 4096
 DEFAULT_MAX_TOOL_ROUNDS = 3
+DEFAULT_TOP_P = 1.0
+DEFAULT_TOP_K = -1  # -1 disables top-k truncation (matches GEM paper Table 3)
 TERMINAL_OBSERVATION = "<TERMINAL>"
 _MS_PER_SECOND = 1000.0
 
@@ -194,6 +196,8 @@ def _build_completion_kwargs(
     *,
     temperature: float,
     max_tokens: int = DEFAULT_MAX_RESPONSE_TOKENS,
+    top_p: float = DEFAULT_TOP_P,
+    top_k: int = DEFAULT_TOP_K,
 ) -> dict[str, Any]:
     """Build LiteLLM ``completion()`` kwargs for a given provider.
 
@@ -201,11 +205,17 @@ def _build_completion_kwargs(
       - ``ollama/``    → local Ollama server (base/completion models, /api/generate)
       - ``bedrock/``   → AWS Bedrock (managed inference)
       - ``sagemaker/`` → AWS SageMaker (custom TGI endpoints)
+
+    ``top_k <= 0`` is treated as "disabled" and not forwarded, matching the
+    GEM paper's ``top_k = -1`` convention. Bedrock's ``converse`` API does
+    not accept a top-level ``top_k`` for non-Anthropic models, so when set
+    it is passed via ``additional_model_request_fields``.
     """
     kwargs: dict[str, Any] = {
         "model": model_id,
         "temperature": temperature,
         "max_tokens": max_tokens,
+        "top_p": top_p,
     }
     # AWS providers need explicit region for LiteLLM's boto3 calls
     if model_id.startswith(("bedrock/", "sagemaker/")):
@@ -218,6 +228,19 @@ def _build_completion_kwargs(
         # Base (completion) models don't have a built-in stop condition;
         # without these, they repeat the prompt/answer indefinitely.
         kwargs["stop"] = ["<|endoftext|>", "<|im_end|>", "\n### User:", "\nHuman:"]
+
+    if top_k > 0:
+        if model_id.startswith("bedrock/"):
+            # Bedrock converse only accepts top_k natively for Anthropic models;
+            # route everything else through additional_model_request_fields so
+            # model-native APIs that understand top_k still receive it.
+            if "anthropic" in model_id:
+                kwargs["top_k"] = top_k
+            else:
+                kwargs["additional_model_request_fields"] = {"top_k": top_k}
+        else:
+            kwargs["top_k"] = top_k
+
     return kwargs
 
 
@@ -227,6 +250,8 @@ def generate_smoke_action(
     messages: list[ChatMessage],
     temperature: float,
     max_tokens: int = DEFAULT_MAX_RESPONSE_TOKENS,
+    top_p: float = DEFAULT_TOP_P,
+    top_k: int = DEFAULT_TOP_K,
 ) -> tuple[str, LLMCallMetadata]:
     """Run one LLM completion and convert usage into trajectory metadata."""
     if model_id.startswith("bedrock/"):
@@ -239,6 +264,8 @@ def generate_smoke_action(
             model_id,
             temperature=temperature,
             max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
         ),
     )
     latency_ms = (time.monotonic() - t0) * _MS_PER_SECOND
@@ -525,6 +552,8 @@ class GEMEpisodeRunner:
         temperature: float,
         max_steps: int,
         max_response_tokens: int = DEFAULT_MAX_RESPONSE_TOKENS,
+        top_p: float = DEFAULT_TOP_P,
+        top_k: int = DEFAULT_TOP_K,
         seed: int | None = None,
         experiment_name: str | None = None,
         tools: list[str] | None = None,
@@ -544,6 +573,8 @@ class GEMEpisodeRunner:
         self._temperature = temperature
         self._max_steps = max_steps
         self._max_response_tokens = max_response_tokens
+        self._top_p = top_p
+        self._top_k = top_k
         self._seed = seed
         self._experiment_name = experiment_name
         self._tools = [_normalize_tool_name(tool_name) for tool_name in (tools or [])]
@@ -581,12 +612,18 @@ class GEMEpisodeRunner:
         episode_index: int = 0,
         seed_override: int | None = None,
         expected_observation: str | None = None,
+        temperature_override: float | None = None,
     ) -> TrajectoryLog:
         """Run one episode and return the validated trajectory log.
 
         Used by GEMSolverModule during GEPA training. Persistence is
         disabled to avoid DB thrash across hundreds of GEPA rollouts —
         use ``run_episode(persist=True)`` for eval or debugging.
+
+        ``temperature_override`` lets the caller swap the per-call sampling
+        temperature without mutating the shared runner state — used by GEPA
+        to score valset examples greedily while trainset rollouts stay
+        stochastic (per GEM paper Table 3).
         """
         return (
             self.run_episode(
@@ -595,6 +632,7 @@ class GEMEpisodeRunner:
                 seed_override=seed_override,
                 expected_observation=expected_observation,
                 persist=False,
+                temperature_override=temperature_override,
             ).trajectory
             or _raise_missing_trajectory()
         )
@@ -607,14 +645,13 @@ class GEMEpisodeRunner:
         seed_override: int | None = None,
         expected_observation: str | None = None,
         persist: bool = True,
+        temperature_override: float | None = None,
     ) -> GEMEpisodeResult:
         """Run one episode and optionally persist its trajectory log."""
         if not prompt.strip():
             raise ValueError("prompt must not be blank")
 
-        gem = importlib.import_module("gem")
-        importlib.import_module("gem.envs")
-        env = gem.make(self._environment_id)
+        env = make_env(self._environment_id)
 
         resolved_seed = seed_override
         if resolved_seed is None and self._seed is not None:
@@ -658,6 +695,7 @@ class GEMEpisodeRunner:
                     observation=current_observation,
                     system_prompt=prompt,
                     history=conversation,
+                    temperature_override=temperature_override,
                 )
                 episode_events.extend(agent_step.logging_events)
                 episode_logging.numeric_anomaly_count += agent_step.numeric_anomaly_count
@@ -811,6 +849,7 @@ class GEMEpisodeRunner:
         messages: list[ChatMessage],
         *,
         include_tools: bool = True,
+        temperature_override: float | None = None,
     ) -> tuple[str, LLMCallMetadata, list[dict[str, Any]], list[LoggingEvent]]:
         """Run one LLM completion, returning text, metadata, and native tool calls.
 
@@ -826,10 +865,15 @@ class GEMEpisodeRunner:
         if self._model_id.startswith("bedrock/"):
             settings.validate_aws()
 
+        effective_temperature = (
+            temperature_override if temperature_override is not None else self._temperature
+        )
         completion_kwargs = _build_completion_kwargs(
             self._model_id,
-            temperature=self._temperature,
+            temperature=effective_temperature,
             max_tokens=self._max_response_tokens,
+            top_p=self._top_p,
+            top_k=self._top_k,
         )
         if include_tools and self._litellm_tools:
             completion_kwargs["tools"] = self._litellm_tools
@@ -920,6 +964,7 @@ class GEMEpisodeRunner:
         observation: str,
         system_prompt: str,
         history: list[ChatMessage],
+        temperature_override: float | None = None,
     ) -> AgentStepResult:
         tool_calls: list[ToolCall] = []
         llm_calls: list[LLMCallMetadata] = []
@@ -936,7 +981,8 @@ class GEMEpisodeRunner:
                 history=step_history,
             )
             response_text, llm_call, native_tool_calls, llm_logging_events = self._generate_action(
-                messages
+                messages,
+                temperature_override=temperature_override,
             )
             llm_calls.append(llm_call)
             logging_events.extend(llm_logging_events)
@@ -998,6 +1044,7 @@ class GEMEpisodeRunner:
             response_text, llm_call, _, llm_logging_events = self._generate_action(
                 messages,
                 include_tools=False,
+                temperature_override=temperature_override,
             )
             llm_calls.append(llm_call)
             logging_events.extend(llm_logging_events)

--- a/src/trajectory_aware_gym/adapters/gem_solver_module.py
+++ b/src/trajectory_aware_gym/adapters/gem_solver_module.py
@@ -43,9 +43,22 @@ class GEMSolverModule(dspy.Module):
         runner: GEMEpisodeRunner,
         *,
         default_instructions: str = "",
+        val_seeds: frozenset[int] | None = None,
+        val_temperature: float | None = None,
     ) -> None:
+        """Wire a runner for GEPA compile.
+
+        ``val_seeds`` and ``val_temperature`` together let GEPA score its
+        valset examples greedily while trainset rollouts stay stochastic.
+        When the forward call's ``seed`` is in ``val_seeds``, the runner
+        is invoked with ``temperature_override=val_temperature`` — matching
+        the GEM paper's "sampling temperature, evaluation = 0.0" column
+        (Table 3) without needing a second runner instance.
+        """
         super().__init__()
         self._runner = runner
+        self._val_seeds = val_seeds
+        self._val_temperature = val_temperature
         sig = GEMSolverSignature
         if default_instructions:
             sig = sig.with_instructions(default_instructions)
@@ -69,10 +82,14 @@ class GEMSolverModule(dspy.Module):
 
     def forward(self, *, problem: str, seed: int | None = None, **kwargs: Any) -> dspy.Prediction:
         system_prompt = self.instructions or "You are a helpful assistant."
+        temperature_override: float | None = None
+        if self._val_seeds is not None and seed is not None and seed in self._val_seeds:
+            temperature_override = self._val_temperature
         trajectory = self._runner.run(
             system_prompt,
             seed_override=seed,
             expected_observation=problem,
+            temperature_override=temperature_override,
         )
         answer = _extract_final_answer(trajectory)
 

--- a/src/trajectory_aware_gym/experiments/runner.py
+++ b/src/trajectory_aware_gym/experiments/runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import hashlib
-import importlib
 import json
 import logging
 import os
@@ -710,7 +709,16 @@ def _build_task_lm(config: ExperimentConfig, task_model: TaskModelConfig) -> Any
         "model": task_model.model_id,
         "temperature": config.eval_protocol.temperature_train,
         "max_tokens": config.eval_protocol.max_response_tokens,
+        "top_p": config.eval_protocol.top_p,
     }
+    # top_k <= 0 means disabled per GEM paper convention (Table 3).
+    top_k = config.eval_protocol.top_k
+    if top_k > 0:
+        model_id = task_model.model_id
+        if task_model.provider == "bedrock" and "anthropic" not in model_id:
+            kwargs["additional_model_request_fields"] = {"top_k": top_k}
+        else:
+            kwargs["top_k"] = top_k
     if task_model.provider == "ollama":
         kwargs["api_base"] = settings.ollama.api_base
     if task_model.provider in ("bedrock", "sagemaker"):
@@ -722,9 +730,9 @@ def _build_task_lm(config: ExperimentConfig, task_model: TaskModelConfig) -> Any
 
 def _build_examples(config: ExperimentConfig, start_seed: int, count: int) -> list[dspy.Example]:
     """Build dspy.Example list by resetting GEM env with sequential seeds."""
-    gem = importlib.import_module("gem")
-    importlib.import_module("gem.envs")
-    env = gem.make(config.environment.gem_env_id)
+    from trajectory_aware_gym.adapters.gem_env_factory import make_env
+
+    env = make_env(config.environment.gem_env_id)
 
     examples: list[dspy.Example] = []
     for index in range(count):
@@ -839,6 +847,8 @@ def _run_eval_task(
         temperature=config.eval_protocol.temperature_eval,
         max_steps=config.environment.max_steps,
         max_response_tokens=config.eval_protocol.max_response_tokens,
+        top_p=config.eval_protocol.top_p,
+        top_k=config.eval_protocol.top_k,
         seed=config.seeds.data_seed + config.environment.train_size,
         experiment_name=config.name,
         tools=config.environment.active_tool_names,
@@ -1205,12 +1215,28 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                     temperature=config.eval_protocol.temperature_train,
                     max_steps=config.environment.max_steps,
                     max_response_tokens=config.eval_protocol.max_response_tokens,
+                    top_p=config.eval_protocol.top_p,
+                    top_k=config.eval_protocol.top_k,
                     seed=config.seeds.data_seed,
                     experiment_name=config.name,
                     tools=config.environment.active_tool_names,
                     experiment_run_id=exp_run_id,
                 )
-                module = GEMSolverModule(runner, default_instructions=seed_prompt)
+                # GEPA reuses one module for both trainset rollouts and
+                # valset Pareto scoring. Mark the valset seeds so the module
+                # forces greedy (eval temp) decoding on those calls — matches
+                # GEM Table 3: train=1.0, evaluation=0.0.
+                val_seed_set = frozenset(
+                    int(seed)
+                    for seed in (getattr(ex, "seed", None) for ex in valset)
+                    if seed is not None
+                )
+                module = GEMSolverModule(
+                    runner,
+                    default_instructions=seed_prompt,
+                    val_seeds=val_seed_set,
+                    val_temperature=config.eval_protocol.temperature_eval,
+                )
 
                 gepa_log_dir = replication_dir / "gepa_logs"
                 gepa_log_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_experiment_runner.py
+++ b/tests/unit/test_experiment_runner.py
@@ -298,7 +298,7 @@ def test_run_experiment_writes_full_replication_artifacts(
             self.episode_history = tuple(train_results)
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class FakeGEPA:
@@ -648,8 +648,8 @@ def test_extract_reflection_usage_adds_numeric_completion_cost() -> None:
 # ── dataset/eval helpers ───────────────────────────────────────────────────
 
 
-def _fake_gem_env(seen_seeds: list[int], env_closed: dict[str, bool], prefix: str = "obs"):
-    """Create a fake GEM environment and gem module for testing _build_examples."""
+def _fake_make_env(seen_seeds: list[int], env_closed: dict[str, bool], prefix: str = "obs"):
+    """Return a fake ``make_env`` that yields a stub GEM env for _build_examples."""
 
     class FakeEnv:
         def reset(self, *, seed: int):
@@ -661,30 +661,21 @@ def _fake_gem_env(seen_seeds: list[int], env_closed: dict[str, bool], prefix: st
 
     fake_env = FakeEnv()
 
-    class FakeGem:
-        @staticmethod
-        def make(_env_id: str):
-            return fake_env
+    def _make_env(_env_id: str, **_kwargs: Any) -> FakeEnv:
+        return fake_env
 
-    def fake_import_module(name: str):
-        if name == "gem":
-            return FakeGem
-        if name == "gem.envs":
-            return SimpleNamespace()
-        raise ModuleNotFoundError(name)
-
-    return fake_import_module
+    return _make_env
 
 
 def test_build_examples_uses_expected_seeds_and_closes_env() -> None:
-    import importlib
+    import trajectory_aware_gym.adapters.gem_env_factory as factory_module
 
     config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
     seen_seeds: list[int] = []
     env_closed = {"value": False}
-    fake_import = _fake_gem_env(seen_seeds, env_closed, "train")
+    fake_make = _fake_make_env(seen_seeds, env_closed, "train")
 
-    with patch.object(importlib, "import_module", side_effect=fake_import):
+    with patch.object(factory_module, "make_env", side_effect=fake_make):
         trainset = _build_examples(config, config.seeds.data_seed, config.environment.train_size)
 
     assert len(trainset) == config.environment.train_size
@@ -694,15 +685,15 @@ def test_build_examples_uses_expected_seeds_and_closes_env() -> None:
 
 
 def test_build_examples_eval_uses_offset_seed_and_closes_env() -> None:
-    import importlib
+    import trajectory_aware_gym.adapters.gem_env_factory as factory_module
 
     config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
     seen_seeds: list[int] = []
     env_closed = {"value": False}
-    fake_import = _fake_gem_env(seen_seeds, env_closed, "eval")
+    fake_make = _fake_make_env(seen_seeds, env_closed, "eval")
 
     start_seed = config.seeds.data_seed + config.environment.train_size
-    with patch.object(importlib, "import_module", side_effect=fake_import):
+    with patch.object(factory_module, "make_env", side_effect=fake_make):
         examples = _build_examples(config, start_seed, config.environment.effective_eval_size)
 
     assert len(examples) == config.environment.effective_eval_size
@@ -977,6 +968,102 @@ def test_build_task_lm_sagemaker_passes_region(monkeypatch: pytest.MonkeyPatch) 
     assert "api_base" not in captured
 
 
+def _capture_task_lm_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    model: Any,
+    top_p: float,
+    top_k: int,
+) -> dict[str, Any]:
+    """Run _build_task_lm with overridden top_p/top_k and return the LM kwargs."""
+    import trajectory_aware_gym.experiments.runner as runner_module
+    from trajectory_aware_gym.models.experiment import ExperimentConfig
+
+    config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
+    config = config.model_copy(
+        update={
+            "eval_protocol": config.eval_protocol.model_copy(
+                update={"top_p": top_p, "top_k": top_k}
+            )
+        }
+    )
+
+    captured: dict = {}
+
+    def fake_lm(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(runner_module.dspy, "LM", fake_lm)
+    runner_module._build_task_lm(config, model)
+    return captured
+
+
+def test_build_task_lm_forwards_top_p_and_disabled_top_k(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trajectory_aware_gym.models.experiment import TaskModelConfig
+
+    model = TaskModelConfig(
+        name="Llama-3.1-8B-Instruct",
+        model_id="bedrock/us.meta.llama3-1-8b-instruct-v1:0",
+        provider="bedrock",
+        parameter_count="8B",
+    )
+    captured = _capture_task_lm_kwargs(monkeypatch, model=model, top_p=0.95, top_k=-1)
+
+    assert captured["top_p"] == pytest.approx(0.95)
+    assert "top_k" not in captured
+    assert "additional_model_request_fields" not in captured
+
+
+def test_build_task_lm_routes_top_k_for_bedrock_non_anthropic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trajectory_aware_gym.models.experiment import TaskModelConfig
+
+    model = TaskModelConfig(
+        name="Llama-3.1-8B-Instruct",
+        model_id="bedrock/us.meta.llama3-1-8b-instruct-v1:0",
+        provider="bedrock",
+        parameter_count="8B",
+    )
+    captured = _capture_task_lm_kwargs(monkeypatch, model=model, top_p=1.0, top_k=40)
+
+    assert "top_k" not in captured
+    assert captured["additional_model_request_fields"] == {"top_k": 40}
+
+
+def test_build_task_lm_routes_top_k_for_bedrock_anthropic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trajectory_aware_gym.models.experiment import TaskModelConfig
+
+    model = TaskModelConfig(
+        name="Claude-Sonnet-4-5",
+        model_id="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        provider="bedrock",
+        parameter_count="n/a",
+    )
+    captured = _capture_task_lm_kwargs(monkeypatch, model=model, top_p=1.0, top_k=40)
+
+    assert captured["top_k"] == 40
+    assert "additional_model_request_fields" not in captured
+
+
+def test_build_task_lm_ollama_uses_top_level_top_k(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trajectory_aware_gym.models.experiment import TaskModelConfig
+
+    model = TaskModelConfig(
+        name="Qwen3-1.7B",
+        model_id="ollama/qwen3-1.7b-base",
+        provider="ollama",
+        parameter_count="1.7B",
+    )
+    captured = _capture_task_lm_kwargs(monkeypatch, model=model, top_p=1.0, top_k=40)
+
+    assert captured["top_k"] == 40
+    assert "additional_model_request_fields" not in captured
+
+
 # ── _budget_alert_fraction ─────────────────────────────────────────────────
 
 
@@ -1120,7 +1207,7 @@ def _setup_fake_runner(
             self.episode_history = (train_result,)
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class FakeGEPA:
@@ -1325,7 +1412,7 @@ def test_run_experiment_exception_writes_failed_status_and_reraises(
             self.episode_history = ()
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class BrokenGEPA:
@@ -1379,7 +1466,7 @@ def test_run_experiment_continue_on_failure_runs_remaining_seeds(
             self.episode_history = (train_result,)
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class FlakyGEPA:
@@ -1448,7 +1535,7 @@ def test_run_experiment_fail_fast_aborts_remaining_seeds(
             self.episode_history = ()
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class BrokenGEPA:
@@ -1505,7 +1592,7 @@ def test_run_experiment_result_none_when_no_detailed_results(
             self.episode_history = (episode,)
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class FakeGEPA:
@@ -1777,7 +1864,7 @@ def test_run_experiment_resume_gepa_done_reuses_experiment_run_id(
             self.episode_history = ()
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class ShouldNotCompileGEPA:
@@ -1944,7 +2031,7 @@ def test_run_experiment_resume_gepa_done_preserves_saved_phase_artifacts(
             self.episode_history = ()
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class ShouldNotCompileGEPA:
@@ -2112,7 +2199,7 @@ def test_run_experiment_updates_failed_on_exception(
             self.episode_history = ()
 
     class FakeSolverModule:
-        def __init__(self, runner, default_instructions: str):
+        def __init__(self, runner, default_instructions: str, **kwargs):
             self.instructions = default_instructions
 
     class BrokenGEPA:

--- a/tests/unit/test_gem_episode_runner.py
+++ b/tests/unit/test_gem_episode_runner.py
@@ -12,6 +12,7 @@ from litellm.exceptions import ServiceUnavailableError  # type: ignore[import-un
 import trajectory_aware_gym.adapters.gem_episode_runner as gem_runner_module
 from trajectory_aware_gym.adapters.gem_episode_runner import (
     GEMEpisodeRunner,
+    _build_completion_kwargs,
     _build_litellm_tools,
     _extract_json_payload,
     _reset_inference_semaphore,
@@ -29,30 +30,12 @@ def _reset_signal_patch():
     gem_runner_module._signal_patch_applied = False
 
 
-class _FakeGemModule:
-    def __init__(self, env):
-        self._env = env
-
-    def make(self, environment_id: str, **kwargs: object):
+def _fake_make_env_factory(env):
+    def _fake_make_env(environment_id: str, **_kwargs: object):
         assert environment_id
-        return self._env
+        return env
 
-
-def _fake_import_module_factory(env):
-    fake_gem = _FakeGemModule(env)
-
-    def _fake_import_module(name: str):
-        if name == "gem":
-            return fake_gem
-        if name == "gem.envs":
-            return SimpleNamespace()
-        if name == "gem.utils.math_grader":
-            # The runner monkey-patches this module's run_with_timeout_signal
-            # to bypass signal-based timeout in worker threads.
-            return SimpleNamespace(run_with_timeout_signal=lambda *a, **kw: None)
-        raise AssertionError(f"unexpected import: {name}")
-
-    return _fake_import_module
+    return _fake_make_env
 
 
 def _make_response(text: str, *, prompt_tokens: int = 7, completion_tokens: int = 5):
@@ -79,8 +62,8 @@ def test_run_episode_records_trajectory_and_cost(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -202,8 +185,8 @@ def test_run_episode_executes_tool_call_before_final_action(monkeypatch):
     )
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -255,8 +238,8 @@ def test_runner_tracks_episode_history(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -294,8 +277,8 @@ def test_run_episode_sanitizes_non_finite_completion_cost(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -341,8 +324,8 @@ def test_run_episode_save_failure_is_non_fatal(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -396,8 +379,8 @@ def test_run_episode_retries_transient_completion_error(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
 
     calls: list[int] = []
@@ -844,8 +827,8 @@ class TestToolRoundExhaustion:
             return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=usage)
 
         monkeypatch.setattr(
-            "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-            _fake_import_module_factory(FakeEnv()),
+            "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+            _fake_make_env_factory(FakeEnv()),
         )
         monkeypatch.setattr(
             "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -895,8 +878,8 @@ def test_cost_type_unavailable_when_completion_cost_raises(monkeypatch):
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -933,8 +916,8 @@ def test_cost_type_unavailable_for_ollama_when_completion_cost_returns_zero(monk
             return None
 
     monkeypatch.setattr(
-        "trajectory_aware_gym.adapters.gem_episode_runner.importlib.import_module",
-        _fake_import_module_factory(FakeEnv()),
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
     )
     monkeypatch.setattr(
         "trajectory_aware_gym.adapters.gem_episode_runner.completion",
@@ -962,3 +945,158 @@ def test_cost_type_unavailable_for_ollama_when_completion_cost_returns_zero(monk
 
 def _raise_on_cost(*, completion_response):
     raise Exception("Model not mapped in LiteLLM pricing")
+
+
+# ── Sampling parameter wiring (top_p / top_k / temperature_override) ──────
+# These tests pin the contract with the GEM paper's Table 3 sampling
+# controls: train=1.0, eval=0.0, top_p=1.0, top_k=-1 (disabled).
+
+
+class TestBuildCompletionKwargsSampling:
+    """``_build_completion_kwargs`` must thread top_p and top_k correctly."""
+
+    def test_top_p_always_passed_through(self):
+        kwargs = _build_completion_kwargs(
+            "bedrock/us.meta.llama3-1-8b-instruct-v1:0",
+            temperature=0.0,
+            top_p=0.9,
+        )
+        assert kwargs["top_p"] == pytest.approx(0.9)
+
+    @pytest.mark.parametrize("top_k", [-1, 0])
+    def test_top_k_disabled_is_not_forwarded(self, top_k):
+        kwargs = _build_completion_kwargs(
+            "bedrock/us.meta.llama3-1-8b-instruct-v1:0",
+            temperature=0.0,
+            top_k=top_k,
+        )
+        assert "top_k" not in kwargs
+        assert "additional_model_request_fields" not in kwargs
+
+    def test_top_k_for_bedrock_anthropic_goes_top_level(self):
+        kwargs = _build_completion_kwargs(
+            "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            temperature=0.0,
+            top_k=40,
+        )
+        assert kwargs["top_k"] == 40
+        assert "additional_model_request_fields" not in kwargs
+
+    def test_top_k_for_bedrock_non_anthropic_uses_additional_fields(self):
+        kwargs = _build_completion_kwargs(
+            "bedrock/us.meta.llama3-1-8b-instruct-v1:0",
+            temperature=0.0,
+            top_k=40,
+        )
+        assert "top_k" not in kwargs
+        assert kwargs["additional_model_request_fields"] == {"top_k": 40}
+
+    @pytest.mark.parametrize(
+        "model_id",
+        ["ollama/qwen3-1.7b-base", "sagemaker/qwen3-4b-base"],
+    )
+    def test_top_k_for_non_bedrock_providers_is_top_level(self, model_id):
+        kwargs = _build_completion_kwargs(model_id, temperature=0.0, top_k=40)
+        assert kwargs["top_k"] == 40
+        assert "additional_model_request_fields" not in kwargs
+
+
+class TestTemperatureOverride:
+    """``GEMEpisodeRunner.run()`` must honor temperature_override per call."""
+
+    def _build_runner_with_capture(self, monkeypatch, *, init_temp: float):
+        captured: list[dict[str, Any]] = []
+
+        class FakeEnv:
+            def reset(self, **_kwargs):
+                return "Solve 2+2", {}
+
+            def step(self, _action):
+                return "", 1.0, True, False, {}
+
+            def close(self):
+                return None
+
+        def fake_completion(**kwargs):
+            captured.append(kwargs)
+            return _make_response("\\boxed{4}")
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+            _fake_make_env_factory(FakeEnv()),
+        )
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            fake_completion,
+        )
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion_cost",
+            lambda *, completion_response: 0.0,
+        )
+
+        runner = GEMEpisodeRunner(
+            environment_id="math:Orz57K",
+            model_id="ollama/qwen3-1.7b-base",
+            temperature=init_temp,
+            max_steps=1,
+            seed=0,
+        )
+        return runner, captured
+
+    def test_override_wins_over_init_temperature(self, monkeypatch):
+        runner, captured = self._build_runner_with_capture(monkeypatch, init_temp=1.0)
+        runner.run("Solve it.", temperature_override=0.0)
+        assert captured[0]["temperature"] == pytest.approx(0.0)
+
+    def test_none_override_uses_init_temperature(self, monkeypatch):
+        runner, captured = self._build_runner_with_capture(monkeypatch, init_temp=1.0)
+        runner.run("Solve it.", temperature_override=None)
+        assert captured[0]["temperature"] == pytest.approx(1.0)
+
+    def test_runner_forwards_top_p_top_k_to_completion(self, monkeypatch):
+        captured: list[dict[str, Any]] = []
+
+        class FakeEnv:
+            def reset(self, **_kwargs):
+                return "q", {}
+
+            def step(self, _action):
+                return "", 1.0, True, False, {}
+
+            def close(self):
+                return None
+
+        def fake_completion(**kwargs):
+            captured.append(kwargs)
+            return _make_response("\\boxed{4}")
+
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+            _fake_make_env_factory(FakeEnv()),
+        )
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+            fake_completion,
+        )
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.completion_cost",
+            lambda *, completion_response: 0.0,
+        )
+
+        runner = GEMEpisodeRunner(
+            environment_id="math:Orz57K",
+            model_id="bedrock/us.meta.llama3-1-8b-instruct-v1:0",
+            temperature=1.0,
+            top_p=0.95,
+            top_k=50,
+            max_steps=1,
+            seed=0,
+        )
+        monkeypatch.setattr(
+            "trajectory_aware_gym.adapters.gem_episode_runner.settings.validate_aws",
+            lambda: None,
+        )
+        runner.run("Solve it.")
+
+        assert captured[0]["top_p"] == pytest.approx(0.95)
+        assert captured[0]["additional_model_request_fields"] == {"top_k": 50}

--- a/tests/unit/test_gem_solver_module.py
+++ b/tests/unit/test_gem_solver_module.py
@@ -59,6 +59,7 @@ class TestGEMSolverModule:
             "Be precise.",
             seed_override=42,
             expected_observation="test",
+            temperature_override=None,
         )
 
     def test_instructions_property(self, mock_runner):
@@ -82,6 +83,7 @@ class TestGEMSolverModule:
             "Be precise.",
             seed_override=None,
             expected_observation="test",
+            temperature_override=None,
         )
 
     def test_forward_invokes_predictor_for_gepa_trace(self, mock_runner):
@@ -152,3 +154,71 @@ class TestExtractFinalAnswer:
             num_steps=0,
         )
         assert _extract_final_answer(trajectory) == "[no-steps]"
+
+
+class TestValSeedTemperatureOverride:
+    """GEPA reuses one module for trainset rollouts + valset Pareto scoring.
+
+    When the forward call's seed is in ``val_seeds``, the module must pass
+    ``temperature_override=val_temperature`` so valset scoring is greedy,
+    matching GEM paper Table 3 (evaluation temperature = 0.0).
+    """
+
+    def test_val_seed_triggers_override(self, mock_runner):
+        module = GEMSolverModule(
+            mock_runner,
+            default_instructions="Be precise.",
+            val_seeds=frozenset({100, 101, 102}),
+            val_temperature=0.0,
+        )
+        module(problem="test", seed=101)
+
+        mock_runner.run.assert_called_once_with(
+            "Be precise.",
+            seed_override=101,
+            expected_observation="test",
+            temperature_override=0.0,
+        )
+
+    def test_non_val_seed_keeps_runner_temperature(self, mock_runner):
+        module = GEMSolverModule(
+            mock_runner,
+            default_instructions="Be precise.",
+            val_seeds=frozenset({100, 101, 102}),
+            val_temperature=0.0,
+        )
+        module(problem="test", seed=42)
+
+        mock_runner.run.assert_called_once_with(
+            "Be precise.",
+            seed_override=42,
+            expected_observation="test",
+            temperature_override=None,
+        )
+
+    def test_absent_val_seeds_never_overrides(self, mock_runner):
+        module = GEMSolverModule(mock_runner, default_instructions="Be precise.")
+        module(problem="test", seed=101)
+
+        mock_runner.run.assert_called_once_with(
+            "Be precise.",
+            seed_override=101,
+            expected_observation="test",
+            temperature_override=None,
+        )
+
+    def test_none_seed_does_not_match_val_seeds(self, mock_runner):
+        module = GEMSolverModule(
+            mock_runner,
+            default_instructions="Be precise.",
+            val_seeds=frozenset({100}),
+            val_temperature=0.0,
+        )
+        module(problem="test")  # seed defaults to None
+
+        mock_runner.run.assert_called_once_with(
+            "Be precise.",
+            seed_override=None,
+            expected_observation="test",
+            temperature_override=None,
+        )


### PR DESCRIPTION
## Summary

Three coupled changes to align our experiment runs with the GEM paper's Table 3 sampling controls (train temp=1.0, eval temp=0.0, top_p=1.0, top_k=-1) and to eliminate Hugging Face rate-limit failures that were killing long eval phases.

### 1. Per-process HF dataset cache via `make_env` factory
`gem.make` re-ran `datasets.load_dataset` on every episode, firing HEAD requests to HF for each of ~2900 env constructions in a full orz57k-notool run. With 32 concurrent eval workers this hit HTTP 429 repeatedly. The new `adapters/gem_env_factory.py` looks up `dataset_name` from GEM's registry, loads the dataset once (thread-safe), and passes it via the `dataset=` kwarg that `MathEnv`/`QaEnv`/`CodeEnv`/`MathVisualEnv` all accept. First episode in a process warms the cache; every subsequent episode reuses the in-memory `DatasetDict`.

### 2. `top_p` / `top_k` actually reach the model
`eval_protocol.top_p` and `eval_protocol.top_k` were parsed from YAML but never read. Bedrock was applying per-model defaults, so we weren't matching the paper's controls. Now threaded through `_build_completion_kwargs`, `GEMEpisodeRunner`, and `_build_task_lm`:
- `top_p` always forwarded
- `top_k <= 0` treated as "disabled" per the paper's `-1` convention and skipped entirely
- `top_k > 0` on Bedrock non-Anthropic models routed via `additional_model_request_fields` (Bedrock `converse` rejects top-level `top_k` for Llama/Mistral/Gemma/Nemotron); Anthropic/Ollama/SageMaker get it at the top level

### 3. Greedy valset scoring during GEPA compile
GEPA reuses one `GEMSolverModule` for both trainset rollouts (temp=1.0, stochastic) and valset Pareto scoring (should be greedy per Table 3). Previously both ran at `temperature_train`, so val scores were noisy at temp=1.0 — the same candidate prompt could get different Pareto scores on re-eval.

Added `temperature_override` to `GEMEpisodeRunner.run` and plumbed `val_seeds` + `val_temperature` through `GEMSolverModule`. When the forward seed is in `val_seeds`, the module flips to greedy decoding. Since `_build_trainset` and `_build_valset` produce disjoint seed ranges, this cleanly distinguishes calls without touching DSPy's call conventions.

With ~97% of GEPA compile rollouts going to valset Pareto scoring, this is the bigger lever than (2) for deterministic candidate selection.

## Test plan
- [x] Full suite (863 tests, +18 new)
- [x] `poe lint` / pyright / bandit all clean
- [x] New `TestBuildCompletionKwargsSampling` covers top_p passthrough, disabled top_k, anthropic vs non-anthropic Bedrock routing, non-Bedrock top-level top_k
- [x] New `TestTemperatureOverride` covers override-wins, none-uses-init, top_p/top_k threaded end-to-end through the full `run` chain
- [x] New `TestValSeedTemperatureOverride` covers hit, miss, absent-val_seeds, None-seed
- [x] New `_build_task_lm` tests cover all four `top_k` routing branches
- [ ] Live smoke: run one orz57k-notool replication to confirm HF no longer rate-limits and val scores now stabilize across iterations