### PR TITLE
fix: patch upstream noise in GEM QaEnv, search, and GEPA progress

### DIFF
--- a/docs/05-operations/common_issues.md
+++ b/docs/05-operations/common_issues.md
@@ -88,3 +88,25 @@ timeouts. Python 3.13 warns when forking in a multi-threaded process.
 used for a 1-second grading timeout and works correctly in practice.
 
 **Affected components:** `gem.envs.math_env.MathEnv.__init__` (upstream).
+
+---
+
+### GEM `QaEnv.step()` raises `UnboundLocalError` when no answer is extractable
+
+**Symptom:** `UnboundLocalError: cannot access local variable 'is_correct'
+where it is not associated with a value` originating from
+`gem/envs/qa_env.py:100`. Seen during HotpotQA / QA evaluation when the model
+output doesn't contain the required `<answer>...</answer>` tag (or
+`\boxed{...}` when `extract_boxed=True`).
+
+**Cause:** Upstream `QaEnv.step` only binds `is_correct` inside the `else`
+branch that runs when the extractor finds an answer. If the extractor returns
+`None`, the method sets `reward = 0.0` but leaves `is_correct` unbound, then
+reads it unconditionally in the final `return`.
+
+**Fix / Workaround:** Patched at runtime by
+`trajectory_aware_gym.adapters.gem_env_factory._apply_upstream_patches`, which
+replaces `QaEnv.step` with a version that defaults `is_correct = False`. The
+patch is applied the first time `make_env` runs and is idempotent.
+
+**Affected components:** `gem.envs.qa_env.QaEnv.step` (upstream).

--- a/experiments/hotpotqa-notool/config.yaml
+++ b/experiments/hotpotqa-notool/config.yaml
@@ -39,7 +39,7 @@ eval_protocol:
   temperature_eval: 0.0
   top_p: 1.0
   top_k: -1
-  rollouts_per_task: 5
+  rollouts_per_task: 1
   tost_margin: 0.05
   tost_alpha: 0.05
   bootstrap_iterations: 1000

--- a/experiments/hotpotqa-tool/config.yaml
+++ b/experiments/hotpotqa-tool/config.yaml
@@ -49,7 +49,7 @@ eval_protocol:
   temperature_eval: 0.0
   top_p: 1.0
   top_k: -1
-  rollouts_per_task: 5
+  rollouts_per_task: 1
   tost_margin: 0.05
   tost_alpha: 0.05
   bootstrap_iterations: 1000

--- a/src/trajectory_aware_gym/adapters/gem_env_factory.py
+++ b/src/trajectory_aware_gym/adapters/gem_env_factory.py
@@ -19,6 +19,40 @@ from typing import Any
 
 _dataset_cache: dict[str, Any] = {}
 _cache_lock = threading.Lock()
+_patches_applied = False
+_patch_lock = threading.Lock()
+
+
+def _apply_upstream_patches() -> None:
+    """Patch known upstream GEM bugs. Idempotent and thread-safe.
+
+    ``QaEnv.step`` fails with ``UnboundLocalError`` when the model output
+    contains no extractable answer: ``is_correct`` is never bound, but the
+    final ``return`` reads it unconditionally. We replace ``step`` with a
+    version that defaults ``is_correct`` to ``False``.
+    """
+    global _patches_applied
+    if _patches_applied:
+        return
+
+    with _patch_lock:
+        if _patches_applied:
+            return
+
+        qa_env = importlib.import_module("gem.envs.qa_env")
+
+        def _patched_step(self: Any, action: str) -> tuple[str, float, bool, bool, dict[str, Any]]:
+            is_correct = False
+            model_answer = self.extractor(action)
+            if model_answer is None:
+                reward = 0.0
+            else:
+                is_correct = self.check_correct(model_answer, self.answer)
+                reward = 1.0 if is_correct else 0.0
+            return qa_env.TERMINAL_STATE, reward, True, True, {"correct": bool(is_correct)}
+
+        qa_env.QaEnv.step = _patched_step
+        _patches_applied = True
 
 
 def _load_env_dataset(env_id: str) -> Any | None:
@@ -65,6 +99,7 @@ def make_env(env_id: str, **kwargs: Any) -> Any:
     ``dataset=`` override.
     """
     gem = importlib.import_module("gem")
+    _apply_upstream_patches()
 
     if "dataset" not in kwargs:
         cached = _load_env_dataset(env_id)
@@ -78,3 +113,6 @@ def reset_dataset_cache() -> None:
     """Clear the cache (for test isolation)."""
     with _cache_lock:
         _dataset_cache.clear()
+    global _patches_applied
+    with _patch_lock:
+        _patches_applied = False

--- a/src/trajectory_aware_gym/experiments/runner.py
+++ b/src/trajectory_aware_gym/experiments/runner.py
@@ -35,6 +35,7 @@ from trajectory_aware_gym.models.experiment import (
     TaskModelConfig,
 )
 from trajectory_aware_gym.models.gepa_result import GEPARunResult, accuracy_from_subscores
+from trajectory_aware_gym.optimizers.gepa_progress_patch import enable_gepa_eval_progress
 from trajectory_aware_gym.storage import (
     ExperimentRunRecord,
     LoggingEvent,
@@ -1241,6 +1242,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                 gepa_log_dir = replication_dir / "gepa_logs"
                 gepa_log_dir.mkdir(parents=True, exist_ok=True)
 
+                enable_gepa_eval_progress()
                 optimizer = dspy.GEPA(
                     metric=metric,
                     **gepa_budget_kwargs,

--- a/src/trajectory_aware_gym/mcp/tools/search.py
+++ b/src/trajectory_aware_gym/mcp/tools/search.py
@@ -1,8 +1,23 @@
+import logging
 from typing import Any
 
 from ddgs import DDGS
 
 from trajectory_aware_gym.mcp.server import mcp
+
+# Yahoo consistently fails with `RequestError` under parallel load and Mojeek
+# returns `403 Forbidden`, together producing dozens of INFO-level tracebacks
+# per minute without contributing results. `ddgs` has no exclusion syntax, so
+# we pass an explicit allow-list of the remaining backends. Keep in sync with
+# `ddgs.engines.ENGINES["text"]`.
+_SEARCH_BACKENDS = "brave,duckduckgo,google,grokipedia,wikipedia,yandex"
+
+# `ddgs` uses `primp` for HTTP, which logs every response at INFO. `ddgs.ddgs`
+# itself logs per-engine errors at INFO too — both are expected chatter in a
+# meta-search and drown real failures. Raise both to WARNING at import time so
+# the noise is suppressed regardless of entry point (runner, tests, notebooks).
+logging.getLogger("primp").setLevel(logging.WARNING)
+logging.getLogger("ddgs.ddgs").setLevel(logging.WARNING)
 
 
 @mcp.tool()
@@ -16,7 +31,7 @@ def search(query: str) -> dict[str, Any]:
     """
     try:
         with DDGS() as ddgs:
-            results = list(ddgs.text(query, max_results=5))
+            results = list(ddgs.text(query, max_results=5, backend=_SEARCH_BACKENDS))
 
         formatted = [
             {

--- a/src/trajectory_aware_gym/optimizers/gepa_progress_patch.py
+++ b/src/trajectory_aware_gym/optimizers/gepa_progress_patch.py
@@ -1,0 +1,57 @@
+"""Enable per-example progress for GEPA's inner valset evaluations.
+
+Upstream `gepa.core.engine` ticks its "GEPA Optimization: X/N rollouts" bar
+only once per iteration, after the full valset eval finishes — the user sees
+no progress for minutes, then a 300-rollout jump. `gepa` exposes no
+per-rollout callback, but DSPy's `Evaluate` (used inside
+``dspy.teleprompt.gepa.gepa_utils.DspyAdapter.evaluate``) does accept
+``display_progress=True``; GEPA just doesn't pass it.
+
+This module replaces the ``Evaluate`` symbol in ``gepa_utils`` with a
+subclass that defaults ``display_progress=True``. Result: an inner per-example
+bar redraws during each valset eval, giving live feedback while the outer
+GEPA bar still ticks in iteration-sized chunks. Idempotent and thread-safe.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from typing import Any
+
+_patch_applied = False
+_patch_lock = threading.Lock()
+
+
+def enable_gepa_eval_progress() -> None:
+    """Patch DSPy's GEPA adapter so inner valset evals show live progress."""
+    global _patch_applied
+    if _patch_applied:
+        return
+
+    with _patch_lock:
+        if _patch_applied:
+            return
+
+        gepa_utils = importlib.import_module("dspy.teleprompt.gepa.gepa_utils")
+        original_evaluate = gepa_utils.Evaluate
+
+        class _EvaluateWithProgress(original_evaluate):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                kwargs.setdefault("display_progress", True)
+                super().__init__(*args, **kwargs)
+
+        gepa_utils.Evaluate = _EvaluateWithProgress  # pyright: ignore[reportAttributeAccessIssue]
+        _patch_applied = True
+
+
+def reset_gepa_eval_progress_patch() -> None:
+    """Undo the patch (for test isolation). Restores the original `Evaluate`."""
+    global _patch_applied
+    with _patch_lock:
+        if not _patch_applied:
+            return
+        gepa_utils = importlib.import_module("dspy.teleprompt.gepa.gepa_utils")
+        wrapper = gepa_utils.Evaluate
+        gepa_utils.Evaluate = wrapper.__bases__[0]  # pyright: ignore[reportAttributeAccessIssue]
+        _patch_applied = False

--- a/tests/unit/test_gem_env_factory.py
+++ b/tests/unit/test_gem_env_factory.py
@@ -1,0 +1,70 @@
+"""Tests for the GEM env factory, including upstream bug patches."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from trajectory_aware_gym.adapters import gem_env_factory
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory_state():
+    gem_env_factory.reset_dataset_cache()
+    yield
+    gem_env_factory.reset_dataset_cache()
+
+
+def test_qa_env_step_returns_incorrect_when_answer_not_extractable():
+    """Without the patch, QaEnv.step raises UnboundLocalError when the
+    model output contains no extractable answer tag. The patched step
+    must return ``correct=False`` with reward 0.0 instead.
+    """
+    gem_env_factory._apply_upstream_patches()
+
+    qa_env = importlib.import_module("gem.envs.qa_env")
+
+    class _StubQaEnv:
+        extractor = staticmethod(lambda _action: None)
+        answer = "42"
+
+        def check_correct(self, _model_answer, _answer):  # pragma: no cover
+            raise AssertionError("check_correct must not be called when extractor returns None")
+
+    obs, reward, terminated, truncated, info = qa_env.QaEnv.step(_StubQaEnv(), "no answer here")
+
+    assert obs == qa_env.TERMINAL_STATE
+    assert reward == 0.0
+    assert terminated is True
+    assert truncated is True
+    assert info == {"correct": False}
+
+
+def test_qa_env_step_reports_correct_when_extractor_matches():
+    gem_env_factory._apply_upstream_patches()
+
+    qa_env = importlib.import_module("gem.envs.qa_env")
+
+    class _StubQaEnv:
+        extractor = staticmethod(lambda action: action.strip())
+        answer = "paris"
+
+        @staticmethod
+        def check_correct(model_answer, answer):
+            return model_answer.lower() == answer.lower()
+
+    _obs, reward, _terminated, _truncated, info = qa_env.QaEnv.step(_StubQaEnv(), "Paris")
+
+    assert reward == 1.0
+    assert info == {"correct": True}
+
+
+def test_apply_upstream_patches_is_idempotent():
+    gem_env_factory._apply_upstream_patches()
+    qa_env = importlib.import_module("gem.envs.qa_env")
+    patched_step = qa_env.QaEnv.step
+
+    gem_env_factory._apply_upstream_patches()
+
+    assert qa_env.QaEnv.step is patched_step

--- a/tests/unit/test_gepa_progress_patch.py
+++ b/tests/unit/test_gepa_progress_patch.py
@@ -1,0 +1,61 @@
+"""Tests for the GEPA inner-eval progress bar monkey-patch."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from trajectory_aware_gym.optimizers.gepa_progress_patch import (
+    enable_gepa_eval_progress,
+    reset_gepa_eval_progress_patch,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_patch():
+    reset_gepa_eval_progress_patch()
+    yield
+    reset_gepa_eval_progress_patch()
+
+
+def test_enable_gepa_eval_progress_forces_display_progress():
+    gepa_utils = importlib.import_module("dspy.teleprompt.gepa.gepa_utils")
+    original_evaluate = gepa_utils.Evaluate
+
+    enable_gepa_eval_progress()
+
+    patched = gepa_utils.Evaluate
+    assert patched is not original_evaluate
+    assert issubclass(patched, original_evaluate)
+
+    instance = patched(devset=[], metric=lambda *_: 0.0)
+    assert instance.display_progress is True
+
+
+def test_enable_gepa_eval_progress_respects_explicit_override():
+    enable_gepa_eval_progress()
+    gepa_utils = importlib.import_module("dspy.teleprompt.gepa.gepa_utils")
+    instance = gepa_utils.Evaluate(devset=[], metric=lambda *_: 0.0, display_progress=False)
+    assert instance.display_progress is False
+
+
+def test_enable_gepa_eval_progress_is_idempotent():
+    enable_gepa_eval_progress()
+    gepa_utils = importlib.import_module("dspy.teleprompt.gepa.gepa_utils")
+    patched_once = gepa_utils.Evaluate
+
+    enable_gepa_eval_progress()
+
+    assert gepa_utils.Evaluate is patched_once
+
+
+def test_reset_restores_original_evaluate():
+    gepa_utils = importlib.import_module("dspy.teleprompt.gepa.gepa_utils")
+    original_evaluate = gepa_utils.Evaluate
+
+    enable_gepa_eval_progress()
+    assert gepa_utils.Evaluate is not original_evaluate
+
+    reset_gepa_eval_progress_patch()
+    assert gepa_utils.Evaluate is original_evaluate

--- a/tests/unit/test_search_tool.py
+++ b/tests/unit/test_search_tool.py
@@ -8,9 +8,11 @@ class _FakeDDGS:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def text(self, query: str, max_results: int):
+    def text(self, query: str, max_results: int, backend: str):
         assert query == "OpenAI"
         assert max_results == 5
+        assert "yahoo" not in backend
+        assert "mojeek" not in backend
         return [
             {
                 "title": "OpenAI",
@@ -36,7 +38,7 @@ class _FailingDDGS:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def text(self, query: str, max_results: int):
+    def text(self, query: str, max_results: int, backend: str):
         raise RuntimeError("network unavailable")
 
 


### PR DESCRIPTION
## Summary

- Monkey-patch `gem.envs.qa_env.QaEnv.step` to default `is_correct=False`, preventing `UnboundLocalError` when the model output has no extractable answer tag.
- Drop `yahoo` and `mojeek` from the `ddgs` backend allow-list and raise `primp` / `ddgs.ddgs` loggers to `WARNING` so only real errors surface.
- Monkey-patch DSPy's GEPA adapter to pass `display_progress=True` to the inner `Evaluate`, giving per-example progress during each valset eval instead of 300-rollout silent jumps.

## Related Issues

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- New `trajectory_aware_gym.optimizers.gepa_progress_patch` module wired into the experiment runner right before `dspy.GEPA(...)`.
- `gem_env_factory.make_env` now applies idempotent upstream GEM patches on first call.
- `mcp.tools.search` passes an explicit backend allow-list and silences `primp` / `ddgs.ddgs` INFO loggers at import time.
- Documented the GEM `QaEnv` patch in `docs/05-operations/common_issues.md`.
- Dropped `rollouts_per_task` from 5 to 1 in both HotpotQA experiment configs for faster dev iteration.

## Testing

- [x] Tests pass locally (`poe test`)
- [x] Linting passes (`poe lint`)
- [x] Type checking passes (`poe typecheck`)

### Test Commands Run

\`\`\`bash
uv run pytest tests/unit/test_gem_env_factory.py tests/unit/test_gepa_progress_patch.py tests/unit/test_search_tool.py tests/unit/test_experiment_runner.py --no-cov
\`\`\`

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged