### PR TITLE
fix(logging): preserve unknown usage and audit eval failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,9 @@ The project evaluates two optimization paradigms:
 **Trajectory Storage** (`src/trajectory_aware_gym/storage/`):
 - SQLite-backed persistence for trajectory logs, tool call records, and experiment runs (`trajectories.db`)
 - WAL mode enabled for concurrent read access during writes
-- Schema version 1.3.0 — tables: `episodes`, `steps`, `llm_calls`, `tool_calls`, `experiment_runs`
+- Schema version 1.4.0 — tables: `episodes`, `steps`, `llm_calls`, `tool_calls`, `experiment_runs`
 - Legacy pre-v1.2 SQLite files are migrated in place on first open before new indexes are created
-- `llm_calls` tracks `provider` (derived from model_id prefix: `ollama/`, `bedrock/`, `sagemaker/`), `cost_type` (currently `"actual"` | `"unavailable"` in stored rows), `latency_ms`, and `cost_usd` per call
+- `llm_calls` tracks `provider` (derived from model_id prefix: `ollama/`, `bedrock/`, `sagemaker/`), `token_usage_known`, `cost_type` (currently `"actual"` | `"unavailable"` in stored rows), `latency_ms`, and `cost_usd` per call
 - `tool_calls` tracks `duration_ms` per tool execution
 - `experiment_runs` table (24 columns): full experiment-level registry with the effective runtime config snapshot (including CLI overrides), operator, git info, status lifecycle (`running` → `gepa_done` → `completed` | `failed`), result/cost summaries, `error_summary`, and `logging_summary`
 - Episodes link to experiment runs via nullable `experiment_run_id` FK
@@ -121,7 +121,7 @@ The project evaluates two optimization paradigms:
 - Resume semantics: `run_metadata.json` persists `experiment_run_id` immediately, and resumes from `gepa_done` must reuse that same ID so evaluation, reporting, and any later artifact sync stay attached to one logical replication
 - S3 sync (`storage/s3_upload.py`, `scripts/upload_experiment_artifacts.py`): experiment execution never uploads to S3 directly; post-run sync is explicit and writes `upload_manifest.json` locally. `upload_artifact_bundle()` remains immutable check-before-write, `upload_artifact_bundle_detailed()` returns uploaded/skipped/failed detail, `list_remote_runs()` paginates prefixes, and `download_artifact()` fetches single files. boto3 is imported lazily to avoid a hard dependency
 - Cost normalization (`metrics/cost_normalization.py`): `compute_normalized_cost()` maps Ollama token counts to Bedrock-equivalent USD using reference prices from `cost_normalization.reference_prices` config
-- Faithfulness rules: correctness metrics must use stored `episode_outcome` when available rather than inferring success from positive reward; unknown task-model cost must remain unknown instead of being coerced to zero
+- Faithfulness rules: correctness metrics must use stored `episode_outcome` when available rather than inferring success from positive reward; unknown task-model token usage and cost must remain unknown instead of being coerced to zero
 
 **AWS/LLM Infrastructure** (`src/trajectory_aware_gym/config/`):
 - All LLM calls route through **LiteLLM** for unified provider interface

--- a/docs/03-experiments/production_runner.md
+++ b/docs/03-experiments/production_runner.md
@@ -189,11 +189,16 @@ Key fields:
 
 - `experiment_run_id`, `config_name`, `provider`, `task_model_id`, `environment_id`, `seed`
 - `baseline_eval`, `eval_summary` including `episodes_attempted`, `episodes_completed`, `episodes_scorable`, `failed`, `timed_out`, and `metrics_unavailable`
-- `total_tokens`, `total_tokens_known`, `task_model_cost_usd`, `task_model_cost_known_usd`
-- `reflection_cost_usd`, `total_cost_usd`, `total_cost_known_usd`, `cost_type`
+- `total_tokens`, `total_tokens_known`, `task_model_cost_usd`, `task_model_cost_known_usd`, `task_model_token_data_coverage`, `task_model_cost_data_coverage`
+- `reflection_tokens`, `reflection_tokens_known`, `reflection_token_data_coverage`, `reflection_cost_usd`, `reflection_cost_known_usd`, `reflection_cost_data_coverage`
+- `total_cost_usd`, `total_cost_known_usd`, `cost_type`
 - `normalized_cost_usd`, `normalization_reference`
 - `wall_clock_seconds`, `mean_llm_latency_ms`
 - `git_commit`, `started_at`, `finished_at`, `logging_summary`
+
+Reflection cost/token fields are `null` when the reflection LM returned partial usage data;
+the matching `*_known` and `*_data_coverage` fields still carry the known sum and the
+fraction of reflection calls that reported usage, so partial runs remain auditable.
 
 ## Resume Behavior
 

--- a/docs/03-experiments/production_runner.md
+++ b/docs/03-experiments/production_runner.md
@@ -97,11 +97,13 @@ results/
                 ├── pareto_frontier.json # Pareto frontier of candidate prompts
                 ├── cost_summary.json    # Token/cost breakdown (task vs reflection, train vs eval)
                 ├── run_report.json      # Unified summary (identical keys across providers)
+                ├── validation_audit.json # Validation-side audit trail (baseline vs best candidate)
                 ├── training_metrics.csv  # Per-episode metrics (training only)
                 ├── training_metrics_summary.json  # Aggregated training-phase stats
                 ├── raw_metrics.csv      # Per-episode metrics (held-out eval only)
                 ├── raw_metrics.jsonl    # Same data, JSONL format
-                ├── raw_metrics_summary.json  # Held-out eval stats split by baseline vs optimized
+                ├── raw_metrics_summary.json  # Held-out eval stats plus denominator breakdowns
+                ├── eval_failure_manifest.jsonl # Held-out eval exceptions/timeouts with phase + seed
                 ├── upload_manifest.json # Written only by the separate S3 sync script
                 └── gepa_logs/           # GEPA internal optimization logs
 ```
@@ -170,6 +172,9 @@ The upload script scans local replication folders, requires `run_metadata.json` 
 | `cost_summary.json` | Token/cost breakdown |
 | `optimized_prompt.txt` | GEPA-evolved system prompt |
 | `fitness_history.json` | Fitness scores per GEPA iteration |
+| `validation_audit.json` | Validation-side baseline/best-candidate audit details |
+| `raw_metrics_summary.json` | Held-out eval summaries plus attempted/completed/scorable denominators |
+| `eval_failure_manifest.jsonl` | Held-out eval exception/timeout records |
 | `run_report.json` | Unified cross-provider summary with provider, accuracy, cost, timing, and logging fields |
 
 S3 key format: `{s3_prefix}{experiment_run_id}/{filename}`
@@ -183,7 +188,7 @@ A unified summary with identical JSON keys regardless of provider (Bedrock or Ol
 Key fields:
 
 - `experiment_run_id`, `config_name`, `provider`, `task_model_id`, `environment_id`, `seed`
-- `baseline_eval`, `eval_summary`
+- `baseline_eval`, `eval_summary` including `episodes_attempted`, `episodes_completed`, `episodes_scorable`, `failed`, `timed_out`, and `metrics_unavailable`
 - `total_tokens`, `total_tokens_known`, `task_model_cost_usd`, `task_model_cost_known_usd`
 - `reflection_cost_usd`, `total_cost_usd`, `total_cost_known_usd`, `cost_type`
 - `normalized_cost_usd`, `normalization_reference`
@@ -229,7 +234,18 @@ Per-replication cost breakdown:
 
 ### raw_metrics.csv / .jsonl
 
-One row per held-out evaluation episode (baseline eval + optimized eval). Fields match the `EpisodeRawMetrics` schema documented in [phase3_raw_metrics.md](phase3_raw_metrics.md).
+One row per held-out evaluation episode that completed with `raw_metrics` available
+(baseline eval + optimized eval). Fields match the `EpisodeRawMetrics` schema documented
+in [phase3_raw_metrics.md](phase3_raw_metrics.md). Denominator counts for attempted,
+completed, scorable, failed, timed-out, and metrics-unavailable episodes live in
+`raw_metrics_summary.json`, `run_metadata.json`, and `run_report.json`.
+
+### validation_audit.json
+
+Validation-side audit artifact written per replication. When GEPA detailed results are
+available, it records the baseline and best-candidate validation subscores, accuracies,
+correct counts, and candidate indices. Resume paths that only have the saved GEPA result
+still emit this file with `details_available: false` so missing detail stays explicit.
 
 ### training_metrics.csv / .jsonl
 
@@ -242,7 +258,7 @@ The experiment config controls three distinct data partitions via the `environme
 | Field | Location | Purpose | Default |
 |-------|----------|---------|---------|
 | `train_size` | `environment` | Number of training examples for GEPA optimization | (required) |
-| `val_size` | `environment` | Validation set size (subset of trainset) | 10% of `train_size` |
+| `val_size` | `environment` | Validation set size (disjoint slice after the train seeds) | 10% of `train_size` when omitted |
 | `eval_size` | `environment.dataset` | Held-out evaluation set size (never seen during optimization) | — |
 
 Seed ranges ensure no overlap between the three disjoint splits
@@ -252,15 +268,15 @@ Seed ranges ensure no overlap between the three disjoint splits
 - **Val**:   seeds `[data_seed + train_size, data_seed + train_size + val_size)`
 - **Eval**:  seeds `[data_seed + train_size + val_size, data_seed + train_size + val_size + eval_size)`
 
-Example from `experiments/orz57k-tool/config.yaml` (with-tool variant):
+Illustrative example when `val_size` is omitted:
 
 ```yaml
 environment:
-  train_size: 500    # 500 Orz57K problems for GEPA optimization
-  # val_size omitted → defaults to 50 (10% of 500)
+  train_size: 500
+  # val_size omitted -> effective_val_size defaults to 50 (10% of 500)
   dataset:
     eval_split: MATH500
-    eval_size: 500   # 500 MATH500 problems for held-out eval
+    eval_size: 500
 ```
 
 ## Experiment Configs

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -127,6 +127,26 @@ def parse_args() -> argparse.Namespace:
             "errors do not silently bias aggregate results across seeds."
         ),
     )
+    parser.add_argument(
+        "--inference-semaphore-size",
+        type=int,
+        default=None,
+        help=(
+            "Cap concurrent LLM requests across the whole run. Overrides "
+            "retry.inference_semaphore_size. Lower this on laptops (e.g. 16) "
+            "to avoid memory pressure and OOM crashes."
+        ),
+    )
+    parser.add_argument(
+        "--max-eval-workers",
+        type=int,
+        default=None,
+        help=(
+            "Cap ThreadPoolExecutor workers for held-out eval. Overrides "
+            "eval_protocol.max_eval_workers. Pair with --inference-semaphore-size "
+            "on laptops."
+        ),
+    )
     parser.set_defaults(fail_fast=True)
     return parser.parse_args()
 
@@ -172,6 +192,8 @@ def main() -> None:
             results_root=args.results_root,
             halt_on_budget_exceeded=args.halt_on_budget_exceeded,
             fail_fast=args.fail_fast,
+            inference_semaphore_size=args.inference_semaphore_size,
+            max_eval_workers=args.max_eval_workers,
         )
     )
 

--- a/src/trajectory_aware_gym/adapters/dspy_adapter.py
+++ b/src/trajectory_aware_gym/adapters/dspy_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 import dspy  # type: ignore[import-untyped]
@@ -11,6 +12,19 @@ from trajectory_aware_gym.adapters.trajectory_logger import TrajectoryLog
 from trajectory_aware_gym.config.core import FitnessModel
 from trajectory_aware_gym.fitness.composite import CompositeFitness
 from trajectory_aware_gym.fitness.types import FitnessResult
+
+
+def _normalize_instructions(value: str | None) -> str:
+    """Return the canonical form ``dspy.Signature`` would store.
+
+    ``Signature.with_instructions`` strips trailing whitespace from the stored
+    value, so normalising to ``rstrip`` on both record and query keeps the
+    comparison robust against YAML ``|`` block-scalars (trailing ``\\n``) and
+    stray trailing spaces in seed prompts.
+    """
+    if value is None:
+        return ""
+    return value.rstrip()
 
 
 class TrajectoryFitnessMetric:
@@ -58,6 +72,12 @@ class TrajectoryFitnessMetric:
         call_w = self._config.call_efficiency_weight
         self._score_max = 1.0 + step_w + call_w  # best case: 1 + 0 + step_w*1 + call_w*1
 
+        # Sidecar outcome log: each call appends (seed, instructions, status).
+        # The runner reads this after GEPA finishes to count how many of the
+        # baseline vs best-program validation episodes were actually scorable.
+        self._outcomes: list[dict[str, Any]] = []
+        self._outcomes_lock = threading.Lock()
+
     def __call__(
         self,
         example: dspy.Example,
@@ -67,8 +87,12 @@ class TrajectoryFitnessMetric:
         pred_trace: Any = None,
     ) -> float | ScoreWithFeedback:
         trajectory: TrajectoryLog | None = getattr(prediction, "trajectory", None)
+        forward_status = str(getattr(prediction, "status", "ok"))
+        instructions = getattr(prediction, "instructions", None)
 
         if trajectory is None:
+            outcome_status = forward_status if forward_status != "ok" else "no_trajectory"
+            self._record_outcome(example, instructions, outcome_status)
             if self._return_feedback:
                 return ScoreWithFeedback(
                     score=0.0,
@@ -78,12 +102,69 @@ class TrajectoryFitnessMetric:
 
         result = self._fitness.evaluate(trajectory)
         score = self._normalize(result.score)
+        self._record_outcome(example, instructions, forward_status)
 
         if self._return_feedback:
             feedback = self._format_feedback(result, score)
             return ScoreWithFeedback(score=score, feedback=feedback)
 
         return score
+
+    def _record_outcome(
+        self,
+        example: dspy.Example,
+        instructions: str | None,
+        status: str,
+    ) -> None:
+        seed = getattr(example, "seed", None)
+        normalized = _normalize_instructions(instructions)
+        with self._outcomes_lock:
+            self._outcomes.append(
+                {
+                    "seed": seed,
+                    "instructions": normalized,
+                    "status": status,
+                }
+            )
+
+    def reset_outcomes(self) -> None:
+        """Clear the outcome sidecar. Call between replications that reuse the metric."""
+        with self._outcomes_lock:
+            self._outcomes.clear()
+
+    def scorable_count(
+        self,
+        instructions: str,
+        *,
+        seeds: frozenset[int] | set[int] | None = None,
+    ) -> int:
+        """Count unique seeds for which this candidate produced a scorable episode.
+
+        "Scorable" = the forward call completed without an infra exception and
+        a trajectory was attached. We deduplicate by seed because GEPA may call
+        the metric multiple times for the same (candidate, seed) pair; the most
+        recent status wins so transient failures on earlier attempts do not
+        mask later successes.
+
+        Instructions strings are normalized (``rstrip``) on both sides because
+        ``dspy.Signature.with_instructions`` strips trailing whitespace from
+        the stored signature — without normalization, a YAML ``|`` block-scalar
+        seed prompt (trailing ``\\n``) would never match the stored value.
+        """
+        target = _normalize_instructions(instructions)
+        latest: dict[int, str] = {}
+        with self._outcomes_lock:
+            rows = list(self._outcomes)
+        for row in rows:
+            if row["instructions"] != target:
+                continue
+            seed = row["seed"]
+            if not isinstance(seed, int):
+                continue
+            if seeds is not None and seed not in seeds:
+                continue
+            latest[seed] = row["status"]
+        return sum(1 for status in latest.values() if status == "ok")
 
     def _normalize(self, raw_score: float) -> float:
         """Clamp negative raw scores to 0 then rescale to [0, 1]."""

--- a/src/trajectory_aware_gym/adapters/gem_episode_runner.py
+++ b/src/trajectory_aware_gym/adapters/gem_episode_runner.py
@@ -7,6 +7,7 @@ import logging
 import math
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -40,6 +41,7 @@ from trajectory_aware_gym.adapters.trajectory_logger import (
     ToolCall,
     TrajectoryLog,
     TrajectoryLogger,
+    resolve_token_usage,
 )
 from trajectory_aware_gym.config import ProjectPaths, settings
 from trajectory_aware_gym.metrics import EpisodeRawMetrics, extract_episode_raw_metrics
@@ -75,15 +77,24 @@ _RETRYABLE_EXCEPTIONS = (
 # ── Inference concurrency semaphore ─────────────────────────────
 _inference_semaphore: threading.Semaphore | None = None
 _semaphore_lock = threading.Lock()
+_inference_semaphore_size_override: int | None = None
 
 
 def _get_inference_semaphore() -> threading.Semaphore:
-    """Lazily initialise the inference semaphore from ``settings.retry``."""
+    """Lazily initialise the inference semaphore.
+
+    Uses the CLI override if set; otherwise falls back to ``settings.retry``.
+    """
     global _inference_semaphore  # noqa: PLW0603
     if _inference_semaphore is None:
         with _semaphore_lock:
             if _inference_semaphore is None:
-                _inference_semaphore = threading.Semaphore(settings.retry.inference_semaphore_size)
+                size = (
+                    _inference_semaphore_size_override
+                    if _inference_semaphore_size_override is not None
+                    else settings.retry.inference_semaphore_size
+                )
+                _inference_semaphore = threading.Semaphore(size)
     return _inference_semaphore
 
 
@@ -91,6 +102,80 @@ def _reset_inference_semaphore() -> None:
     """Reset the module-level semaphore (for test isolation)."""
     global _inference_semaphore  # noqa: PLW0603
     _inference_semaphore = None
+
+
+def set_inference_semaphore_size_override(size: int | None) -> None:
+    """Override ``settings.retry.inference_semaphore_size`` for this process.
+
+    Must be called before the first inference call — subsequent calls to
+    ``set_*`` also reset the underlying semaphore so the next acquire picks
+    up the new size.
+    """
+    global _inference_semaphore_size_override  # noqa: PLW0603
+    if size is not None and size < 1:
+        raise ValueError(f"inference_semaphore_size must be >= 1 (got {size})")
+    _inference_semaphore_size_override = size
+    _reset_inference_semaphore()
+
+
+# ── Episode-level retry on transient failures ──────────────────
+# These are exception types that are worth retrying at the episode level —
+# transient infrastructure issues. Deterministic exceptions (ValueError,
+# TypeError, AssertionError, KeyError) are deliberately excluded so we don't
+# waste compute on actual bugs. LLM-layer exceptions are already retried
+# inside ``_completion_with_retry``; retrying again here would multiply the
+# attempt count. ``tenacity.RetryError`` (raised when ``_completion_with_retry``
+# exhausts) is therefore also excluded.
+_EPISODE_RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    TimeoutError,
+    ConnectionError,
+)
+
+# Max total attempts per episode. Kept conservative so a prompt that
+# systematically fails doesn't waste 3× compute before being recorded.
+_EPISODE_MAX_ATTEMPTS = 2
+
+
+def _is_episode_retryable(exc: Exception) -> bool:
+    """Decide whether an episode-level failure is worth retrying.
+
+    Excludes deterministic bugs (FileNotFoundError etc.) and anything already
+    exhausted by the LLM-layer retry, which would just waste budget.
+    """
+    if isinstance(exc, FileNotFoundError | IsADirectoryError | NotADirectoryError):
+        return False
+    # TimeoutError/ConnectionError plus miscellaneous IO/socket OSErrors.
+    return isinstance(exc, _EPISODE_RETRYABLE_EXCEPTIONS) or isinstance(exc, OSError)
+
+
+def run_episode_with_retry[T](
+    fn: Callable[[], T],
+    *,
+    context_label: str,
+    max_attempts: int = _EPISODE_MAX_ATTEMPTS,
+) -> T:
+    """Run ``fn()`` with bounded retries on transient infrastructure errors.
+
+    Used by both GEM solver forward calls and held-out eval workers to survive
+    transient failures (tool timeouts, connection blips) without retrying
+    deterministic bugs or already-exhausted LLM errors.
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 — allowlist filtered below
+            if attempt >= max_attempts or not _is_episode_retryable(exc):
+                raise
+            logger.warning(
+                "%s failed on attempt %d/%d (%s: %r); retrying",
+                context_label,
+                attempt,
+                max_attempts,
+                type(exc).__name__,
+                exc,
+            )
+    # Unreachable — loop body either returns or raises.
+    raise AssertionError("run_episode_with_retry exited without returning or raising")
 
 
 def _completion_with_retry(
@@ -372,17 +457,11 @@ def _extract_llm_cost(model_id: str, response: Any) -> tuple[float | None, LLMCo
 def _extract_token_usage_metadata(response: Any) -> tuple[int, int, int, bool]:
     """Extract faithful token totals from a LiteLLM response."""
     usage = getattr(response, "usage", None)
-    prompt_raw = getattr(usage, "prompt_tokens", None) if usage is not None else None
-    completion_raw = getattr(usage, "completion_tokens", None) if usage is not None else None
-    total_raw = getattr(usage, "total_tokens", None) if usage is not None else None
-
-    prompt_tokens = int(prompt_raw or 0)
-    completion_tokens = int(completion_raw or 0)
-    if total_raw is not None:
-        return (prompt_tokens, completion_tokens, int(total_raw), True)
-    if prompt_raw is not None and completion_raw is not None:
-        return (prompt_tokens, completion_tokens, prompt_tokens + completion_tokens, True)
-    return (0, 0, 0, False)
+    return resolve_token_usage(
+        getattr(usage, "prompt_tokens", None) if usage is not None else None,
+        getattr(usage, "completion_tokens", None) if usage is not None else None,
+        getattr(usage, "total_tokens", None) if usage is not None else None,
+    )
 
 
 def _make_logging_event(

--- a/src/trajectory_aware_gym/adapters/gem_episode_runner.py
+++ b/src/trajectory_aware_gym/adapters/gem_episode_runner.py
@@ -285,10 +285,9 @@ def generate_smoke_action(
                 action = action[len(prefix) :].strip()
                 break
 
-    usage = getattr(response, "usage", None)
-    prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
-    completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
-    total_tokens = int(getattr(usage, "total_tokens", 0) or (prompt_tokens + completion_tokens))
+    prompt_tokens, completion_tokens, total_tokens, token_usage_known = (
+        _extract_token_usage_metadata(response)
+    )
 
     cost_usd, cost_type = _extract_llm_cost(model_id, response)
 
@@ -297,6 +296,7 @@ def generate_smoke_action(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
         total_tokens=total_tokens,
+        token_usage_known=token_usage_known,
         cost_usd=cost_usd,
         cost_type=cost_type,
         latency_ms=latency_ms,
@@ -367,6 +367,22 @@ def _extract_llm_cost(model_id: str, response: Any) -> tuple[float | None, LLMCo
         return (float(maybe_cost), "actual")
     except Exception:  # noqa: BLE001  # LiteLLM raises bare Exception for unmapped models
         return (None, "unavailable")
+
+
+def _extract_token_usage_metadata(response: Any) -> tuple[int, int, int, bool]:
+    """Extract faithful token totals from a LiteLLM response."""
+    usage = getattr(response, "usage", None)
+    prompt_raw = getattr(usage, "prompt_tokens", None) if usage is not None else None
+    completion_raw = getattr(usage, "completion_tokens", None) if usage is not None else None
+    total_raw = getattr(usage, "total_tokens", None) if usage is not None else None
+
+    prompt_tokens = int(prompt_raw or 0)
+    completion_tokens = int(completion_raw or 0)
+    if total_raw is not None:
+        return (prompt_tokens, completion_tokens, int(total_raw), True)
+    if prompt_raw is not None and completion_raw is not None:
+        return (prompt_tokens, completion_tokens, prompt_tokens + completion_tokens, True)
+    return (0, 0, 0, False)
 
 
 def _make_logging_event(
@@ -916,13 +932,24 @@ class GEMEpisodeRunner:
                     arguments = {}
                 native_tool_calls.append({"tool": name, "arguments": arguments})
 
-        usage = getattr(response, "usage", None)
-        prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
-        completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
-        total_tokens = int(getattr(usage, "total_tokens", 0) or (prompt_tokens + completion_tokens))
+        prompt_tokens, completion_tokens, total_tokens, token_usage_known = (
+            _extract_token_usage_metadata(response)
+        )
 
         cost_usd, cost_type = _extract_llm_cost(self._model_id, response)
 
+        if not token_usage_known:
+            logging_events.append(
+                _make_logging_event(
+                    stage="llm_call",
+                    kind="usage_missing",
+                    field="usage",
+                    message=(
+                        "LiteLLM response did not include complete token usage; "
+                        "token totals remain unknown for this call."
+                    ),
+                )
+            )
         if _is_non_finite_number(latency_ms):
             logging_events.append(
                 _make_logging_event(
@@ -952,6 +979,7 @@ class GEMEpisodeRunner:
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
+            token_usage_known=token_usage_known,
             cost_usd=cost_usd,
             cost_type=cost_type,
             latency_ms=latency_ms,

--- a/src/trajectory_aware_gym/adapters/gem_solver_module.py
+++ b/src/trajectory_aware_gym/adapters/gem_solver_module.py
@@ -9,13 +9,19 @@ to the returned Prediction so the GEPA metric can score it.
 from __future__ import annotations
 
 import copy
+import logging
 from typing import Any, cast
 
 import dspy  # type: ignore[import-untyped]
 from dspy.utils.dummies import DummyLM  # type: ignore[import-untyped]
 
-from trajectory_aware_gym.adapters.gem_episode_runner import GEMEpisodeRunner
+from trajectory_aware_gym.adapters.gem_episode_runner import (
+    GEMEpisodeRunner,
+    run_episode_with_retry,
+)
 from trajectory_aware_gym.adapters.trajectory_logger import TrajectoryLog
+
+logger = logging.getLogger(__name__)
 
 
 class GEMSolverSignature(dspy.Signature):
@@ -85,13 +91,30 @@ class GEMSolverModule(dspy.Module):
         temperature_override: float | None = None
         if self._val_seeds is not None and seed is not None and seed in self._val_seeds:
             temperature_override = self._val_temperature
-        trajectory = self._runner.run(
-            system_prompt,
-            seed_override=seed,
-            expected_observation=problem,
-            temperature_override=temperature_override,
-        )
-        answer = _extract_final_answer(trajectory)
+
+        # Catch runner failures so the metric still gets called and can record
+        # the outcome. DSPy's ParallelExecutor swallows exceptions raised here
+        # and skips the metric entirely, which would hide infra failures from
+        # the validation-scorable count. ``run_episode_with_retry`` adds a
+        # bounded retry on transient infra errors (timeouts, connection blips)
+        # before we give up and mark the episode runner_error.
+        status = "ok"
+        trajectory: TrajectoryLog | None = None
+        try:
+            trajectory = run_episode_with_retry(
+                lambda: self._runner.run(
+                    system_prompt,
+                    seed_override=seed,
+                    expected_observation=problem,
+                    temperature_override=temperature_override,
+                ),
+                context_label=f"GEMSolverModule.forward seed={seed}",
+            )
+        except Exception as exc:  # noqa: BLE001 — GEM/tool layers raise bare Exception
+            logger.warning("GEMSolverModule.forward failed for seed=%s: %r", seed, exc)
+            status = "runner_error"
+
+        answer = _extract_final_answer(trajectory) if trajectory is not None else ""
 
         # GEPA needs a Predict invocation in the DSPy trace to build reflective
         # examples for instruction mutation.  We use a DummyLM so this populates
@@ -101,7 +124,12 @@ class GEMSolverModule(dspy.Module):
         with dspy.context(lm=trace_lm):
             self.predict(problem=problem, seed=seed)
 
-        return dspy.Prediction(answer=answer, trajectory=trajectory)
+        return dspy.Prediction(
+            answer=answer,
+            trajectory=trajectory,
+            status=status,
+            instructions=system_prompt,
+        )
 
 
 def _extract_final_answer(trajectory: TrajectoryLog) -> str:

--- a/src/trajectory_aware_gym/adapters/trajectory_logger.py
+++ b/src/trajectory_aware_gym/adapters/trajectory_logger.py
@@ -440,6 +440,27 @@ def filter_trajectories(
 # ---------------------------------------------------------------------------
 
 
+def resolve_token_usage(
+    prompt_raw: Any,
+    completion_raw: Any,
+    total_raw: Any,
+) -> tuple[int, int, int, bool]:
+    """Canonical rule for turning raw LLM-usage fields into `(prompt, completion, total, known)`.
+
+    Prefers an explicit `total_raw`; otherwise falls back to `prompt + completion`
+    when both are present; otherwise marks usage as unknown with zero totals.
+    Shared by LiteLLM `response.usage` (attr-shaped) and DSPy tracker (dict-shaped)
+    call sites so the two code paths cannot drift.
+    """
+    prompt = int(prompt_raw or 0)
+    completion = int(completion_raw or 0)
+    if total_raw is not None:
+        return (prompt, completion, int(total_raw), True)
+    if prompt_raw is not None and completion_raw is not None:
+        return (prompt, completion, prompt + completion, True)
+    return (0, 0, 0, False)
+
+
 def extract_llm_calls_from_tracker(tracker: Any) -> list[LLMCallMetadata]:
     """Convert a ``dspy.track_usage()`` tracker into LLMCallMetadata entries.
 
@@ -457,20 +478,11 @@ def extract_llm_calls_from_tracker(tracker: Any) -> list[LLMCallMetadata]:
     calls: list[LLMCallMetadata] = []
     for model_id, usages in getattr(tracker, "usage_data", {}).items():
         for usage in usages:
-            prompt_raw = usage.get("prompt_tokens")
-            completion_raw = usage.get("completion_tokens")
-            total_raw = usage.get("total_tokens")
-            prompt = int(prompt_raw or 0)
-            completion = int(completion_raw or 0)
-            if total_raw is not None:
-                total_tokens = int(total_raw)
-                token_usage_known = True
-            elif prompt_raw is not None and completion_raw is not None:
-                total_tokens = prompt + completion
-                token_usage_known = True
-            else:
-                total_tokens = 0
-                token_usage_known = False
+            prompt, completion, total_tokens, token_usage_known = resolve_token_usage(
+                usage.get("prompt_tokens"),
+                usage.get("completion_tokens"),
+                usage.get("total_tokens"),
+            )
             calls.append(
                 LLMCallMetadata(
                     model_id=model_id,

--- a/src/trajectory_aware_gym/adapters/trajectory_logger.py
+++ b/src/trajectory_aware_gym/adapters/trajectory_logger.py
@@ -31,6 +31,7 @@ DSPy integration example::
     trajectory_log = logger.build_log()
 
 Schema version history:
+    1.4.0 - add explicit token_usage_known on llm_calls so missing usage stays unknown.
     1.1.0 - llm_call -> llm_calls (list) to support multiple LM forwards per env step (DSPy).
     1.0.0 - Initial schema with tool call tracking, LLM metadata, and cost aggregation.
 """
@@ -57,7 +58,7 @@ from trajectory_aware_gym.config import ProjectPaths
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = "1.3.0"
+SCHEMA_VERSION = "1.4.0"
 
 type EpisodeOutcome = Literal["success", "failure", "truncated"]
 type LLMCostType = Literal["actual", "estimated", "unavailable"]
@@ -99,6 +100,7 @@ class LLMCallMetadata(BaseModel):
     prompt_tokens: int = Field(ge=0)
     completion_tokens: int = Field(ge=0)
     total_tokens: int = Field(ge=0)
+    token_usage_known: bool = True
     cost_usd: float | None = None
     cost_type: LLMCostType | None = None
     latency_ms: float | None = None
@@ -455,14 +457,27 @@ def extract_llm_calls_from_tracker(tracker: Any) -> list[LLMCallMetadata]:
     calls: list[LLMCallMetadata] = []
     for model_id, usages in getattr(tracker, "usage_data", {}).items():
         for usage in usages:
-            prompt = usage.get("prompt_tokens", 0)
-            completion = usage.get("completion_tokens", 0)
+            prompt_raw = usage.get("prompt_tokens")
+            completion_raw = usage.get("completion_tokens")
+            total_raw = usage.get("total_tokens")
+            prompt = int(prompt_raw or 0)
+            completion = int(completion_raw or 0)
+            if total_raw is not None:
+                total_tokens = int(total_raw)
+                token_usage_known = True
+            elif prompt_raw is not None and completion_raw is not None:
+                total_tokens = prompt + completion
+                token_usage_known = True
+            else:
+                total_tokens = 0
+                token_usage_known = False
             calls.append(
                 LLMCallMetadata(
                     model_id=model_id,
                     prompt_tokens=prompt,
                     completion_tokens=completion,
-                    total_tokens=prompt + completion,
+                    total_tokens=total_tokens,
+                    token_usage_known=token_usage_known,
                     cost_usd=usage.get("cost", None),
                 )
             )

--- a/src/trajectory_aware_gym/experiments/runner.py
+++ b/src/trajectory_aware_gym/experiments/runner.py
@@ -2092,6 +2092,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             )
 
                     finished = _utc_now()
+                    finished_iso = _format_iso(finished)
                     run_report_payload: dict[str, Any] | None = None
                     try:
                         run_report = build_run_report(
@@ -2106,6 +2107,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             reference_prices=settings.cost_normalization.reference_prices,
                             prompt_token_ratio=settings.cost_normalization.prompt_token_ratio,
                             logging_summary=logging_summary.model_dump(mode="json"),
+                            finished_at=finished_iso,
                         )
                         run_report_payload = cast(
                             dict[str, Any],
@@ -2134,7 +2136,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                     metadata.update(
                         {
                             "status": "completed",
-                            "finished_at": _format_iso(finished),
+                            "finished_at": finished_iso,
                             "elapsed_seconds": round((finished - started_at).total_seconds(), 3),
                             "result": result.model_dump(mode="json")
                             if result is not None
@@ -2153,7 +2155,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             _DB_PATH,
                             exp_run_id,
                             status="completed",
-                            finished_at=_format_iso(finished),
+                            finished_at=finished_iso,
                             result_summary=eval_summary,
                             cost_summary=cost_summary,
                             logging_summary=logging_summary,

--- a/src/trajectory_aware_gym/experiments/runner.py
+++ b/src/trajectory_aware_gym/experiments/runner.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import socket
 import time
+import traceback
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,7 +22,12 @@ import yaml
 from litellm import completion_cost  # type: ignore[import-untyped]
 
 from trajectory_aware_gym.adapters.dspy_adapter import TrajectoryFitnessMetric
-from trajectory_aware_gym.adapters.gem_episode_runner import GEMEpisodeResult, GEMEpisodeRunner
+from trajectory_aware_gym.adapters.gem_episode_runner import (
+    GEMEpisodeResult,
+    GEMEpisodeRunner,
+    run_episode_with_retry,
+    set_inference_semaphore_size_override,
+)
 from trajectory_aware_gym.adapters.gem_solver_module import GEMSolverModule
 from trajectory_aware_gym.adapters.trajectory_logger import SCHEMA_VERSION, TrajectoryLog
 from trajectory_aware_gym.config import settings
@@ -34,7 +40,13 @@ from trajectory_aware_gym.models.experiment import (
     ExperimentConfig,
     TaskModelConfig,
 )
-from trajectory_aware_gym.models.gepa_result import GEPARunResult, accuracy_from_subscores
+from trajectory_aware_gym.models.gepa_result import (
+    GEPARunResult,
+    accuracy_from_subscores,
+    build_validation_audit_from_detailed,
+    build_validation_audit_from_result,
+)
+from trajectory_aware_gym.models.reflection_usage import ReflectionUsageSummary
 from trajectory_aware_gym.optimizers.gepa_progress_patch import enable_gepa_eval_progress
 from trajectory_aware_gym.storage import (
     ExperimentRunRecord,
@@ -54,6 +66,7 @@ DEFAULT_RESULTS_ROOT = Path("results")
 _COST_DECIMAL_PLACES = 6
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 _DB_PATH = _PROJECT_ROOT / "logs" / "trajectories.db"
+_EVAL_FAILURE_MANIFEST_NAME = "eval_failure_manifest.jsonl"
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +92,11 @@ class RunExperimentArgs:
     results_root: Path = DEFAULT_RESULTS_ROOT
     halt_on_budget_exceeded: bool = False
     fail_fast: bool = True
+    # Concurrency overrides for laptop-friendly runs. When None, values come
+    # from ``settings.retry.inference_semaphore_size`` and
+    # ``config.eval_protocol.max_eval_workers`` respectively.
+    inference_semaphore_size: int | None = None
+    max_eval_workers: int | None = None
 
 
 def resolve_gepa_budget_kwargs(
@@ -336,82 +354,93 @@ def _raw_metrics_summary_with_omissions(
     }
 
 
-def _empty_reflection_usage_summary() -> dict[str, float | int | None]:
-    return {
-        "total_tokens": 0,
-        "known_total_tokens": 0,
-        "token_data_coverage": 1.0,
-        "total_cost_usd": 0.0,
-        "known_cost_usd": 0.0,
-        "cost_data_coverage": 1.0,
-    }
+def _load_resume_reflection_usage(saved_gepa_phase: dict[str, Any]) -> ReflectionUsageSummary:
+    """Reconstruct reflection usage from a prior run's `gepa_phase_summary`.
+
+    Prefers the full `reflection_usage` dict (current schema); falls back to the
+    legacy `reflection_tokens` / `reflection_cost` scalars. When a scalar is
+    missing, the corresponding `total_*` stays `None` and coverage drops to 0.0
+    so downstream cost reporting stays honest.
+    """
+    saved_reflection_usage = saved_gepa_phase.get("reflection_usage")
+    if isinstance(saved_reflection_usage, dict):
+        return ReflectionUsageSummary.from_saved(saved_reflection_usage)
+
+    saved_tokens_raw = saved_gepa_phase.get("reflection_tokens")
+    saved_cost_raw = saved_gepa_phase.get("reflection_cost")
+    tokens_value: int | None = (
+        int(saved_tokens_raw)
+        if isinstance(saved_tokens_raw, int | float) and not isinstance(saved_tokens_raw, bool)
+        else None
+    )
+    cost_value: float | None = (
+        float(saved_cost_raw)
+        if isinstance(saved_cost_raw, int | float) and not isinstance(saved_cost_raw, bool)
+        else None
+    )
+    return ReflectionUsageSummary(
+        total_tokens=tokens_value,
+        known_total_tokens=tokens_value if tokens_value is not None else 0,
+        token_data_coverage=1.0 if tokens_value is not None else 0.0,
+        total_cost_usd=cost_value,
+        known_cost_usd=cost_value if cost_value is not None else 0.0,
+        cost_data_coverage=1.0 if cost_value is not None else 0.0,
+    )
 
 
-def _coerce_reflection_usage_summary(value: Any) -> dict[str, float | int | None]:
-    if isinstance(value, dict):
-        return {
-            **_empty_reflection_usage_summary(),
-            **value,
-        }
-    if isinstance(value, tuple) and len(value) == 2:
-        tokens, cost = value
-        token_total = int(tokens) if isinstance(tokens, int | float) else None
-        cost_total = float(cost) if isinstance(cost, int | float) else None
-        return {
-            "total_tokens": token_total,
-            "known_total_tokens": token_total or 0,
-            "token_data_coverage": 1.0 if token_total is not None else 0.0,
-            "total_cost_usd": cost_total,
-            "known_cost_usd": cost_total or 0.0,
-            "cost_data_coverage": 1.0 if cost_total is not None else 0.0,
-        }
-    return _empty_reflection_usage_summary()
-
-
-def _extract_reflection_usage(reflection_lm: Any | None) -> dict[str, float | int | None]:
+def _extract_reflection_usage(reflection_lm: Any | None) -> ReflectionUsageSummary:
     if reflection_lm is None:
-        return _empty_reflection_usage_summary()
+        return ReflectionUsageSummary.empty()
 
     history = getattr(reflection_lm, "history", [])
-    entries = [entry for entry in history if isinstance(entry, dict)]
-    if not entries:
-        return _empty_reflection_usage_summary()
-
-    known_total_tokens = 0
-    token_known_entries = 0
-    known_cost_usd = 0.0
-    cost_known_entries = 0
-
-    for entry in entries:
+    raw_entries = [entry for entry in history if isinstance(entry, dict)]
+    normalized: list[dict[str, Any]] = []
+    for entry in raw_entries:
         usage = entry.get("usage")
-        if isinstance(usage, dict):
-            usage_total = usage.get("total_tokens")
-            if isinstance(usage_total, int | float) and not isinstance(usage_total, bool):
-                known_total_tokens += int(usage_total)
-                token_known_entries += 1
+        usage_total = usage.get("total_tokens") if isinstance(usage, dict) else None
 
         response = entry.get("response")
+        entry_cost: float | None = None
         if response is not None:
             try:
                 maybe_cost = completion_cost(completion_response=response)
             except Exception:  # noqa: BLE001  # LiteLLM raises bare Exception for unmapped models
                 maybe_cost = None
             if isinstance(maybe_cost, int | float) and not isinstance(maybe_cost, bool):
-                known_cost_usd += float(maybe_cost)
-                cost_known_entries += 1
+                entry_cost = float(maybe_cost)
+        normalized.append({"usage_total_tokens": usage_total, "cost_usd": entry_cost})
 
-    token_coverage = token_known_entries / len(entries)
-    cost_coverage = cost_known_entries / len(entries)
-    return {
-        "total_tokens": known_total_tokens if token_coverage == 1.0 else None,
-        "known_total_tokens": known_total_tokens,
-        "token_data_coverage": token_coverage,
-        "total_cost_usd": round(known_cost_usd, _COST_DECIMAL_PLACES)
-        if cost_coverage == 1.0
-        else None,
-        "known_cost_usd": round(known_cost_usd, _COST_DECIMAL_PLACES),
-        "cost_data_coverage": cost_coverage,
-    }
+    return ReflectionUsageSummary.from_history(normalized)
+
+
+def _write_replication_summary_md(
+    path: Path, *, banner: str, experiment_run_id: str | None
+) -> None:
+    """Persist the replication summary banner as markdown alongside other artifacts.
+
+    The banner itself has no markdown syntax, so it's wrapped in a fenced
+    ``text`` block to preserve alignment when rendered.
+    """
+    header = "# Replication summary"
+    if experiment_run_id:
+        header += f"\n\n**Run:** `{experiment_run_id}`"
+    body = f"{header}\n\n```text\n{banner}\n```\n"
+    path.write_text(body, encoding="utf-8")
+
+
+def _format_validation_line(
+    label: str,
+    summary: dict[str, Any],
+    total: int,
+    bench: str,
+) -> str:
+    accuracy = summary["accuracy"]
+    correct = summary["correct"]
+    line = f"  Validation: {label} accuracy: {accuracy:.1%} ({correct}/{total})"
+    scorable = summary.get("scorable")
+    if isinstance(scorable, int) and scorable < total:
+        line += f" scorable={scorable}/{total}"
+    return f"{line} ({bench})\n"
 
 
 def _format_eval_detail_line(summary: dict[str, Any]) -> str:
@@ -609,6 +638,16 @@ def _merge_logging_summaries(
         events=events,
         events_truncated=events_truncated,
     )
+
+
+_EXC_MESSAGE_MAX_LEN = 200
+
+
+def _format_exc_context(exc: BaseException) -> str:
+    """Compact `Type: message` form for logging events — truncated, no traceback."""
+    etype = type(exc).__name__
+    message = str(exc)[:_EXC_MESSAGE_MAX_LEN]
+    return f"{etype}: {message}" if message else etype
 
 
 def _append_logging_summary_event(
@@ -810,121 +849,17 @@ def _extract_pareto_frontier(optimized_module: Any) -> list[dict[str, Any]]:
     return []
 
 
-def _build_validation_summary(*, accuracy: float, episodes: int) -> dict[str, Any]:
-    return {
+def _build_validation_summary(
+    *, accuracy: float, episodes: int, scorable: int | None = None
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
         "episodes": episodes,
         "correct": round(accuracy * episodes),
         "accuracy": accuracy,
     }
-
-
-def _normalize_validation_subscores(value: Any) -> dict[str, float] | None:
-    if not isinstance(value, dict):
-        return None
-    out: dict[str, float] = {}
-    for key, score in value.items():
-        if isinstance(score, int | float) and not isinstance(score, bool):
-            out[str(key)] = float(score)
-    return out
-
-
-def _build_validation_audit_from_detailed(
-    optimized_module: Any,
-    *,
-    episodes: int,
-) -> dict[str, Any] | None:
-    detailed = getattr(optimized_module, "detailed_results", None)
-    if detailed is None:
-        return None
-
-    val_scores = getattr(detailed, "val_aggregate_scores", None)
-    val_subscores = getattr(detailed, "val_subscores", None)
-    best_idx = getattr(detailed, "best_idx", None)
-    discovery = getattr(detailed, "discovery_eval_counts", None)
-    if not isinstance(val_scores, list) or not isinstance(val_subscores, list):
-        return None
-    if not val_scores or not val_subscores or not isinstance(best_idx, int):
-        return None
-    if best_idx < 0 or best_idx >= len(val_scores) or best_idx >= len(val_subscores):
-        return None
-
-    baseline_subscores = _normalize_validation_subscores(val_subscores[0])
-    optimized_subscores = _normalize_validation_subscores(val_subscores[best_idx])
-    baseline_accuracy = (
-        accuracy_from_subscores(baseline_subscores) if baseline_subscores is not None else None
-    )
-    optimized_accuracy = (
-        accuracy_from_subscores(optimized_subscores) if optimized_subscores is not None else None
-    )
-
-    def discovery_count(index: int) -> int | None:
-        if isinstance(discovery, list) and index < len(discovery):
-            value = discovery[index]
-            if isinstance(value, int | float) and not isinstance(value, bool):
-                return int(value)
-        return None
-
-    return {
-        "source": "gepa_detailed_results",
-        "episodes": episodes,
-        "candidate_count": len(val_scores),
-        "best_program_index": best_idx,
-        "baseline": {
-            "program_index": 0,
-            "val_aggregate_score": float(val_scores[0]),
-            "accuracy": baseline_accuracy,
-            "correct": round(baseline_accuracy * episodes)
-            if isinstance(baseline_accuracy, int | float)
-            else None,
-            "discovery_eval_count": discovery_count(0),
-            "subscores": baseline_subscores,
-        },
-        "optimized": {
-            "program_index": best_idx,
-            "val_aggregate_score": float(val_scores[best_idx]),
-            "accuracy": optimized_accuracy,
-            "correct": round(optimized_accuracy * episodes)
-            if isinstance(optimized_accuracy, int | float)
-            else None,
-            "discovery_eval_count": discovery_count(best_idx),
-            "subscores": optimized_subscores,
-        },
-    }
-
-
-def _build_validation_audit_from_result(
-    result: GEPARunResult | None,
-    *,
-    episodes: int,
-    source: str,
-) -> dict[str, Any]:
-    if result is None:
-        return {
-            "source": source,
-            "episodes": episodes,
-            "available": False,
-            "details_available": False,
-            "baseline": None,
-            "optimized": None,
-        }
-
-    return {
-        "source": source,
-        "episodes": episodes,
-        "available": True,
-        "details_available": False,
-        "best_program_index": result.best_program_index,
-        "baseline": {
-            "program_index": 0,
-            "accuracy": result.baseline_accuracy,
-            "correct": round(result.baseline_accuracy * episodes),
-        },
-        "optimized": {
-            "program_index": result.best_program_index,
-            "accuracy": result.final_accuracy,
-            "correct": round(result.final_accuracy * episodes),
-        },
-    }
+    if scorable is not None:
+        summary["scorable"] = scorable
+    return summary
 
 
 def _load_json_dict(path: Path) -> dict[str, Any] | None:
@@ -1128,12 +1063,15 @@ def _run_eval_task(
         tools=config.environment.active_tool_names,
         experiment_run_id=experiment_run_id,
     )
-    return runner.run_episode(
-        task.instructions,
-        episode_index=task.episode_index,
-        seed_override=task.seed,
-        expected_observation=task.expected_observation,
-        persist=True,
+    return run_episode_with_retry(
+        lambda: runner.run_episode(
+            task.instructions,
+            episode_index=task.episode_index,
+            seed_override=task.seed,
+            expected_observation=task.expected_observation,
+            persist=True,
+        ),
+        context_label=f"_run_eval_task episode={task.episode_index} seed={task.seed}",
     )
 
 
@@ -1143,6 +1081,7 @@ def _run_heldout_eval(
     task_model_id: str,
     instructions: str,
     experiment_run_id: str | None = None,
+    max_eval_workers_override: int | None = None,
 ) -> tuple[list[GEMEpisodeResult], dict[str, Any]]:
     eval_examples = _eval_examples(config)
     rollouts = config.eval_protocol.rollouts_per_task
@@ -1163,7 +1102,11 @@ def _run_heldout_eval(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     total_tasks = len(tasks)
-    max_workers = config.eval_protocol.max_eval_workers
+    max_workers = (
+        max_eval_workers_override
+        if max_eval_workers_override is not None
+        else config.eval_protocol.max_eval_workers
+    )
     per_episode_timeout = config.eval_protocol.eval_episode_timeout_seconds
     # Total timeout: enough waves to finish all tasks, plus margin.
     waves = math.ceil(total_tasks / max_workers)
@@ -1192,8 +1135,6 @@ def _run_heldout_eval(
                 try:
                     results[idx] = future.result()
                 except Exception as exc:  # noqa: BLE001
-                    import traceback
-
                     logger.exception("Eval episode %d failed", idx)
                     failure_records.append(
                         {
@@ -1298,6 +1239,18 @@ def _run_heldout_eval(
 def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
     """Run a production GEPA experiment across configured models and replications."""
     config = ExperimentConfig.from_yaml(args.config_path)
+
+    # Apply CLI concurrency overrides before any inference happens so the
+    # semaphore is sized correctly on first acquire. ``max_eval_workers`` is
+    # threaded through to ``_run_heldout_eval`` directly — applied at call
+    # sites rather than globally because it only affects that phase.
+    if args.inference_semaphore_size is not None:
+        logger.info(
+            "Overriding inference_semaphore_size: %d (config default=%d)",
+            args.inference_semaphore_size,
+            settings.retry.inference_semaphore_size,
+        )
+        set_inference_semaphore_size_override(args.inference_semaphore_size)
 
     seed_prompt = args.seed_prompt_override or config.seed_prompt
     if args.seed_prompt_override is not None:
@@ -1421,6 +1374,10 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                     )
                     model_entries.setdefault(str(replication_seed), {"status": "skipped"})
                     continue
+
+                # Reset the per-call sidecar so validation-scorable counts for
+                # this replication only see outcomes produced by this GEPA run.
+                metric.reset_outcomes()
 
                 prior_metadata = _load_json_dict(replication_dir / "run_metadata.json") or {}
                 prior_hash = prior_metadata.get("config_hash")
@@ -1571,7 +1528,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                 training_rows: list[EpisodeRawMetrics] = []
                 training_usage = _summarize_task_usage_rows([], metrics_unavailable_episodes=0)
                 training_logging_summary = LoggingSummary()
-                reflection_usage = _empty_reflection_usage_summary()
+                reflection_usage: ReflectionUsageSummary = ReflectionUsageSummary.empty()
                 validation_audit_payload: dict[str, Any] | None = None
                 baseline_eval_results: list[GEMEpisodeResult] = []
                 eval_results: list[GEMEpisodeResult] = []
@@ -1634,39 +1591,10 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                     )
                                 )
 
-                            saved_reflection_usage = saved_gepa_phase.get("reflection_usage")
-                            if isinstance(saved_reflection_usage, dict):
-                                reflection_usage = _coerce_reflection_usage_summary(
-                                    saved_reflection_usage
-                                )
-                            else:
-                                saved_reflection_tokens = saved_gepa_phase.get("reflection_tokens")
-                                saved_reflection_cost = saved_gepa_phase.get("reflection_cost")
-                                if isinstance(saved_reflection_tokens, int | float):
-                                    reflection_usage["total_tokens"] = int(saved_reflection_tokens)
-                                    reflection_usage["known_total_tokens"] = int(
-                                        saved_reflection_tokens
-                                    )
-                                else:
-                                    reflection_usage["total_tokens"] = None
-                                    reflection_usage["token_data_coverage"] = 0.0
-                                if isinstance(saved_reflection_cost, int | float):
-                                    reflection_usage["total_cost_usd"] = float(
-                                        saved_reflection_cost
-                                    )
-                                    reflection_usage["known_cost_usd"] = float(
-                                        saved_reflection_cost
-                                    )
-                                else:
-                                    reflection_usage["total_cost_usd"] = None
-                                    reflection_usage["cost_data_coverage"] = 0.0
+                            reflection_usage = _load_resume_reflection_usage(saved_gepa_phase)
                             if (
-                                saved_reflection_usage is None
-                                and saved_gepa_phase.get("reflection_tokens") is None
-                                and saved_gepa_phase.get("reflection_cost") is None
-                            ) or (
-                                reflection_usage["total_tokens"] is None
-                                or reflection_usage["total_cost_usd"] is None
+                                reflection_usage.total_tokens is None
+                                or reflection_usage.total_cost_usd is None
                             ):
                                 resume_phase_events.append(
                                     LoggingEvent(
@@ -1693,14 +1621,10 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                     )
                                 ],
                             )
-                            reflection_usage = {
-                                "total_tokens": None,
-                                "known_total_tokens": 0,
-                                "token_data_coverage": 0.0,
-                                "total_cost_usd": None,
-                                "known_cost_usd": 0.0,
-                                "cost_data_coverage": 0.0,
-                            }
+                            reflection_usage = ReflectionUsageSummary(
+                                token_data_coverage=0.0,
+                                cost_data_coverage=0.0,
+                            )
 
                         if resume_phase_events:
                             training_logging_summary = _merge_logging_summaries(
@@ -1753,10 +1677,8 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         ]
                         training_usage = _summarize_task_usage(training_results)
                         training_logging_summary = _results_logging_summary(training_results)
-                        reflection_usage = _coerce_reflection_usage_summary(
-                            _extract_reflection_usage(reflection_lm)
-                        )
-                        validation_audit_payload = _build_validation_audit_from_detailed(
+                        reflection_usage = _extract_reflection_usage(reflection_lm)
+                        validation_audit_payload = build_validation_audit_from_detailed(
                             optimized_module,
                             episodes=config.environment.effective_val_size,
                         )
@@ -1779,9 +1701,9 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         metadata["gepa_phase_summary"] = {
                             "training_usage": training_usage,
                             "logging_summary": training_logging_summary.model_dump(mode="json"),
-                            "reflection_usage": reflection_usage,
-                            "reflection_tokens": reflection_usage["total_tokens"],
-                            "reflection_cost": reflection_usage["total_cost_usd"],
+                            "reflection_usage": reflection_usage.model_dump(mode="json"),
+                            "reflection_tokens": reflection_usage.total_tokens,
+                            "reflection_cost": reflection_usage.total_cost_usd,
                         }
                         _write_json(replication_dir / "run_metadata.json", metadata)
                         try:
@@ -1791,7 +1713,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                 status="gepa_done",
                                 optimized_prompt=optimized_prompt,
                             )
-                        except Exception:  # noqa: BLE001
+                        except Exception as exc:  # noqa: BLE001
                             logger.warning(
                                 "update_experiment_run(gepa_done) failed",
                                 exc_info=True,
@@ -1802,8 +1724,9 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                     stage="publish",
                                     kind="experiment_run_update_failed",
                                     message=(
-                                        "Failed to mark the experiment_run record as gepa_done; "
-                                        "local artifacts are still canonical."
+                                        "Failed to mark the experiment_run record as gepa_done "
+                                        f"({_format_exc_context(exc)}); local artifacts are still "
+                                        "canonical."
                                     ),
                                 ),
                             )
@@ -1839,6 +1762,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         task_model_id=model_id,
                         instructions=seed_prompt,
                         experiment_run_id=exp_run_id,
+                        max_eval_workers_override=args.max_eval_workers,
                     )
                     baseline_eval_summary, baseline_eval_failures = _split_eval_summary_artifacts(
                         baseline_eval_summary_raw
@@ -1850,18 +1774,18 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         task_model_id=model_id,
                         instructions=optimized_prompt,
                         experiment_run_id=exp_run_id,
+                        max_eval_workers_override=args.max_eval_workers,
                     )
                     eval_summary, optimized_eval_failures = _split_eval_summary_artifacts(
                         eval_summary_raw
                     )
 
                     heldout_results = baseline_eval_results + eval_results
-                    eval_failure_manifest_name = "eval_failure_manifest.jsonl"
                     eval_failure_records = [
                         {"phase": "baseline", **record} for record in baseline_eval_failures
                     ] + [{"phase": "optimized", **record} for record in optimized_eval_failures]
                     _write_jsonl_records(
-                        replication_dir / eval_failure_manifest_name,
+                        replication_dir / _EVAL_FAILURE_MANIFEST_NAME,
                         eval_failure_records,
                     )
                     heldout_logging_summary = _results_logging_summary(heldout_results)
@@ -1870,12 +1794,12 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             _build_eval_failure_logging_summary(
                                 phase="baseline",
                                 failure_records=baseline_eval_failures,
-                                manifest_name=eval_failure_manifest_name,
+                                manifest_name=_EVAL_FAILURE_MANIFEST_NAME,
                             ),
                             _build_eval_failure_logging_summary(
                                 phase="optimized",
                                 failure_records=optimized_eval_failures,
-                                manifest_name=eval_failure_manifest_name,
+                                manifest_name=_EVAL_FAILURE_MANIFEST_NAME,
                             ),
                         ]
                     )
@@ -1890,13 +1814,26 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                     baseline_validation_summary: dict[str, Any] | None = None
                     optimized_validation_summary: dict[str, Any] | None = None
                     if result is not None:
+                        # The sidecar only has data when GEPA was run in this
+                        # process; on resume it is empty, so scorable stays None.
+                        baseline_scorable: int | None = None
+                        optimized_scorable: int | None = None
+                        if not resumed_from_gepa_done:
+                            baseline_scorable = metric.scorable_count(
+                                seed_prompt, seeds=val_seed_set
+                            )
+                            optimized_scorable = metric.scorable_count(
+                                result.optimized_instructions, seeds=val_seed_set
+                            )
                         baseline_validation_summary = _build_validation_summary(
                             accuracy=result.baseline_accuracy,
                             episodes=val_total,
+                            scorable=baseline_scorable,
                         )
                         optimized_validation_summary = _build_validation_summary(
                             accuracy=result.final_accuracy,
                             episodes=val_total,
+                            scorable=optimized_scorable,
                         )
                     if validation_audit_payload is None:
                         validation_audit_source = (
@@ -1904,7 +1841,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             if resumed_from_gepa_done
                             else "result_summary_only"
                         )
-                        validation_audit_payload = _build_validation_audit_from_result(
+                        validation_audit_payload = build_validation_audit_from_result(
                             result,
                             episodes=val_total,
                             source=validation_audit_source,
@@ -1932,7 +1869,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                 [baseline_eval_summary, eval_summary]
                             ),
                             "eval_failure_manifest": {
-                                "path": eval_failure_manifest_name,
+                                "path": _EVAL_FAILURE_MANIFEST_NAME,
                                 "count": len(eval_failure_records),
                             },
                         },
@@ -1958,31 +1895,20 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         if isinstance(task_cost_known_value, int | float)
                         else 0.0
                     )
-                    reflection_tokens = reflection_usage["total_tokens"]
-                    reflection_tokens_known_value = reflection_usage["known_total_tokens"]
-                    reflection_tokens_known = (
-                        int(reflection_tokens_known_value)
-                        if isinstance(reflection_tokens_known_value, int | float)
-                        else 0
-                    )
-                    reflection_cost = reflection_usage["total_cost_usd"]
-                    reflection_cost_known_value = reflection_usage["known_cost_usd"]
-                    reflection_cost_known = (
-                        float(reflection_cost_known_value)
-                        if isinstance(reflection_cost_known_value, int | float)
-                        else 0.0
-                    )
+                    reflection_tokens = reflection_usage.total_tokens
+                    reflection_tokens_known = reflection_usage.known_total_tokens
+                    reflection_cost = reflection_usage.total_cost_usd
+                    reflection_cost_known = reflection_usage.known_cost_usd
                     total_tokens = (
                         int(task_tokens) + reflection_tokens
-                        if isinstance(task_tokens, int) and isinstance(reflection_tokens, int)
+                        if isinstance(task_tokens, int) and reflection_tokens is not None
                         else None
                     )
                     total_tokens_known = task_tokens_known + reflection_tokens_known
                     total_cost_known = task_cost_known + reflection_cost_known
                     total_cost = (
                         round(total_cost_known, _COST_DECIMAL_PLACES)
-                        if isinstance(task_cost, int | float)
-                        and isinstance(reflection_cost, int | float)
+                        if isinstance(task_cost, int | float) and reflection_cost is not None
                         else None
                     )
                     cost_type = (
@@ -2005,10 +1931,10 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         "task_model_cost_data_coverage": task_usage["cost_data_coverage"],
                         "reflection_tokens": reflection_tokens,
                         "reflection_tokens_known": reflection_tokens_known,
-                        "reflection_token_data_coverage": reflection_usage["token_data_coverage"],
+                        "reflection_token_data_coverage": reflection_usage.token_data_coverage,
                         "reflection_cost": reflection_cost,
                         "reflection_cost_known": round(reflection_cost_known, _COST_DECIMAL_PLACES),
-                        "reflection_cost_data_coverage": reflection_usage["cost_data_coverage"],
+                        "reflection_cost_data_coverage": reflection_usage.cost_data_coverage,
                         "total_tokens": total_tokens,
                         "total_tokens_known": total_tokens_known,
                         "total_cost": total_cost,
@@ -2114,7 +2040,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             json.loads(run_report.model_dump_json()),
                         )
                         _write_json(replication_dir / "run_report.json", run_report_payload)
-                    except Exception:  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         logger.warning(
                             "Failed to generate run report for %s",
                             exp_run_id,
@@ -2126,8 +2052,9 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                 stage="publish",
                                 kind="run_report_failed",
                                 message=(
-                                    "Failed to generate run_report.json; run_metadata.json "
-                                    "and cost_summary.json remain canonical."
+                                    "Failed to generate run_report.json "
+                                    f"({_format_exc_context(exc)}); run_metadata.json and "
+                                    "cost_summary.json remain canonical."
                                 ),
                             ),
                         )
@@ -2160,7 +2087,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             cost_summary=cost_summary,
                             logging_summary=logging_summary,
                         )
-                    except Exception:  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         logger.warning(
                             "update_experiment_run(completed) failed",
                             exc_info=True,
@@ -2171,8 +2098,9 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                 stage="publish",
                                 kind="experiment_run_update_failed",
                                 message=(
-                                    "Failed to update the experiment_run record to completed; "
-                                    "local result artifacts remain canonical."
+                                    "Failed to update the experiment_run record to completed "
+                                    f"({_format_exc_context(exc)}); local result artifacts remain "
+                                    "canonical."
                                 ),
                             ),
                         )
@@ -2203,15 +2131,16 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         baseline_validation_summary is not None
                         and optimized_validation_summary is not None
                     ):
-                        validation_lines = (
-                            f"  Validation: Baseline accuracy:  "
-                            f"{baseline_validation_summary['accuracy']:.1%} "
-                            f"({baseline_validation_summary['correct']}/{val_total}) "
-                            f"({train_bench})\n"
-                            f"  Validation: Optimized accuracy: "
-                            f"{optimized_validation_summary['accuracy']:.1%} "
-                            f"({optimized_validation_summary['correct']}/{val_total}) "
-                            f"({train_bench})\n"
+                        validation_lines = _format_validation_line(
+                            "Baseline ",
+                            baseline_validation_summary,
+                            val_total,
+                            train_bench,
+                        ) + _format_validation_line(
+                            "Optimized",
+                            optimized_validation_summary,
+                            val_total,
+                            train_bench,
                         )
                     else:
                         validation_lines = (
@@ -2236,8 +2165,8 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         if isinstance(total_tokens, int)
                         else f"unknown (known {total_tokens_known:,})"
                     )
-                    print(
-                        f"\n{'=' * 60}\n"
+                    summary_banner = (
+                        f"{'=' * 60}\n"
                         f"  Replication complete: {task_model.name} seed={replication_seed}\n"
                         f"{validation_lines}"
                         f"  Test/eval: Baseline accuracy:  {bl_eval_acc:.1%} "
@@ -2249,8 +2178,13 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         f"  Total cost:         {total_cost_display}\n"
                         f"  Total tokens:       {total_tokens_display}\n"
                         f"  Elapsed:            {(finished - started_at).total_seconds():.1f}s\n"
-                        f"{'=' * 60}",
-                        flush=True,
+                        f"{'=' * 60}"
+                    )
+                    print(f"\n{summary_banner}", flush=True)
+                    _write_replication_summary_md(
+                        replication_dir / "replication_summary.md",
+                        banner=summary_banner,
+                        experiment_run_id=exp_run_id,
                     )
                 except Exception as exc:
                     finished = _utc_now()
@@ -2299,7 +2233,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                     kind="training_trajectory_salvage_failed",
                                     message=(
                                         "Failed to salvage partial GEPA training trajectories "
-                                        f"after replication failure: {salvage_exc!r}"
+                                        f"after replication failure ({_format_exc_context(salvage_exc)})."
                                     ),
                                 )
                             )
@@ -2331,7 +2265,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             error_summary=repr(exc),
                             logging_summary=partial_logging_summary,
                         )
-                    except Exception:  # noqa: BLE001
+                    except Exception as publish_exc:  # noqa: BLE001
                         logger.warning(
                             "update_experiment_run(failed) failed",
                             exc_info=True,
@@ -2343,7 +2277,8 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                 kind="experiment_run_update_failed",
                                 message=(
                                     "Failed to update the experiment_run record with failed "
-                                    "status; local run_metadata.json remains canonical."
+                                    f"status ({_format_exc_context(publish_exc)}); local "
+                                    "run_metadata.json remains canonical."
                                 ),
                             ),
                         )

--- a/src/trajectory_aware_gym/experiments/runner.py
+++ b/src/trajectory_aware_gym/experiments/runner.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import dspy  # type: ignore[import-untyped]
 import yaml
@@ -199,6 +199,13 @@ def _write_jsonl(path: Path, rows: list[EpisodeRawMetrics]) -> None:
             handle.write(json.dumps(row.model_dump(mode="json"), sort_keys=True) + "\n")
 
 
+def _write_jsonl_records(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
 def _write_csv(path: Path, rows: list[EpisodeRawMetrics]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if not rows:
@@ -329,23 +336,59 @@ def _raw_metrics_summary_with_omissions(
     }
 
 
-def _extract_reflection_usage(reflection_lm: Any | None) -> tuple[int, float]:
+def _empty_reflection_usage_summary() -> dict[str, float | int | None]:
+    return {
+        "total_tokens": 0,
+        "known_total_tokens": 0,
+        "token_data_coverage": 1.0,
+        "total_cost_usd": 0.0,
+        "known_cost_usd": 0.0,
+        "cost_data_coverage": 1.0,
+    }
+
+
+def _coerce_reflection_usage_summary(value: Any) -> dict[str, float | int | None]:
+    if isinstance(value, dict):
+        return {
+            **_empty_reflection_usage_summary(),
+            **value,
+        }
+    if isinstance(value, tuple) and len(value) == 2:
+        tokens, cost = value
+        token_total = int(tokens) if isinstance(tokens, int | float) else None
+        cost_total = float(cost) if isinstance(cost, int | float) else None
+        return {
+            "total_tokens": token_total,
+            "known_total_tokens": token_total or 0,
+            "token_data_coverage": 1.0 if token_total is not None else 0.0,
+            "total_cost_usd": cost_total,
+            "known_cost_usd": cost_total or 0.0,
+            "cost_data_coverage": 1.0 if cost_total is not None else 0.0,
+        }
+    return _empty_reflection_usage_summary()
+
+
+def _extract_reflection_usage(reflection_lm: Any | None) -> dict[str, float | int | None]:
     if reflection_lm is None:
-        return (0, 0.0)
+        return _empty_reflection_usage_summary()
 
     history = getattr(reflection_lm, "history", [])
-    total_tokens = 0
-    total_cost = 0.0
+    entries = [entry for entry in history if isinstance(entry, dict)]
+    if not entries:
+        return _empty_reflection_usage_summary()
 
-    for entry in history:
-        if not isinstance(entry, dict):
-            continue
+    known_total_tokens = 0
+    token_known_entries = 0
+    known_cost_usd = 0.0
+    cost_known_entries = 0
 
+    for entry in entries:
         usage = entry.get("usage")
         if isinstance(usage, dict):
             usage_total = usage.get("total_tokens")
-            if isinstance(usage_total, int):
-                total_tokens += usage_total
+            if isinstance(usage_total, int | float) and not isinstance(usage_total, bool):
+                known_total_tokens += int(usage_total)
+                token_known_entries += 1
 
         response = entry.get("response")
         if response is not None:
@@ -353,10 +396,116 @@ def _extract_reflection_usage(reflection_lm: Any | None) -> tuple[int, float]:
                 maybe_cost = completion_cost(completion_response=response)
             except Exception:  # noqa: BLE001  # LiteLLM raises bare Exception for unmapped models
                 maybe_cost = None
-            if isinstance(maybe_cost, int | float):
-                total_cost += float(maybe_cost)
+            if isinstance(maybe_cost, int | float) and not isinstance(maybe_cost, bool):
+                known_cost_usd += float(maybe_cost)
+                cost_known_entries += 1
 
-    return (total_tokens, total_cost)
+    token_coverage = token_known_entries / len(entries)
+    cost_coverage = cost_known_entries / len(entries)
+    return {
+        "total_tokens": known_total_tokens if token_coverage == 1.0 else None,
+        "known_total_tokens": known_total_tokens,
+        "token_data_coverage": token_coverage,
+        "total_cost_usd": round(known_cost_usd, _COST_DECIMAL_PLACES)
+        if cost_coverage == 1.0
+        else None,
+        "known_cost_usd": round(known_cost_usd, _COST_DECIMAL_PLACES),
+        "cost_data_coverage": cost_coverage,
+    }
+
+
+def _format_eval_detail_line(summary: dict[str, Any]) -> str:
+    attempted = int(summary.get("episodes_attempted", 0) or 0)
+    completed = int(summary.get("episodes_completed", 0) or 0)
+    scorable = int(summary.get("episodes_scorable", summary.get("episodes", 0)) or 0)
+    failed = int(summary.get("failed", 0) or 0)
+    timed_out = int(summary.get("timed_out", 0) or 0)
+    metrics_unavailable = int(summary.get("metrics_unavailable", 0) or 0)
+    return (
+        f"attempted={attempted} completed={completed} scorable={scorable} "
+        f"failed={failed} timed_out={timed_out} metrics_unavailable={metrics_unavailable}"
+    )
+
+
+def _split_eval_summary_artifacts(
+    summary: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    sanitized = dict(summary)
+    failure_records_raw = sanitized.pop("failure_records", [])
+    if not isinstance(failure_records_raw, list):
+        return sanitized, []
+
+    failure_records: list[dict[str, Any]] = []
+    for record in failure_records_raw:
+        if isinstance(record, dict):
+            failure_records.append(dict(record))
+    return sanitized, failure_records
+
+
+def _merge_eval_outcome_summaries(summaries: list[dict[str, Any]]) -> dict[str, Any]:
+    attempted = sum(int(summary.get("episodes_attempted", 0) or 0) for summary in summaries)
+    completed = sum(int(summary.get("episodes_completed", 0) or 0) for summary in summaries)
+    scorable = sum(
+        int(summary.get("episodes_scorable", summary.get("episodes", 0)) or 0)
+        for summary in summaries
+    )
+    failed = sum(int(summary.get("failed", 0) or 0) for summary in summaries)
+    timed_out = sum(int(summary.get("timed_out", 0) or 0) for summary in summaries)
+    metrics_unavailable = sum(
+        int(summary.get("metrics_unavailable", 0) or 0) for summary in summaries
+    )
+    successes = sum(int(summary.get("successes", 0) or 0) for summary in summaries)
+    correct = sum(
+        int(summary.get("correct", summary.get("successes", 0)) or 0) for summary in summaries
+    )
+
+    return {
+        "episodes_attempted": attempted,
+        "episodes_completed": completed,
+        "episodes_scorable": scorable,
+        "episodes": scorable,
+        "failed": failed,
+        "timed_out": timed_out,
+        "metrics_unavailable": metrics_unavailable,
+        "successes": successes,
+        "success_rate": (successes / scorable) if scorable else 0.0,
+        "completion_rate": (completed / attempted) if attempted else 0.0,
+        "attempted_success_rate": (successes / attempted) if attempted else 0.0,
+        "correct": correct,
+        "accuracy": (correct / scorable) if scorable else 0.0,
+    }
+
+
+def _build_eval_failure_logging_summary(
+    *,
+    phase: str,
+    failure_records: list[dict[str, Any]],
+    manifest_name: str,
+) -> LoggingSummary:
+    if not failure_records:
+        return LoggingSummary()
+
+    timed_out = sum(1 for record in failure_records if record.get("status") == "timed_out")
+    exceptions = len(failure_records) - timed_out
+    detail_parts: list[str] = []
+    if exceptions:
+        detail_parts.append(f"{exceptions} exception")
+    if timed_out:
+        detail_parts.append(f"{timed_out} timed out")
+    detail = ", ".join(detail_parts) if detail_parts else "failures recorded"
+    return LoggingSummary(
+        status="partial",
+        events=[
+            LoggingEvent(
+                stage="eval",
+                kind="eval_failures_recorded",
+                message=(
+                    f"{phase} eval recorded {len(failure_records)} failed episodes "
+                    f"({detail}); see {manifest_name}."
+                ),
+            )
+        ],
+    )
 
 
 def _result_success(result: GEMEpisodeResult) -> bool | None:
@@ -460,6 +609,21 @@ def _merge_logging_summaries(
         events=events,
         events_truncated=events_truncated,
     )
+
+
+def _append_logging_summary_event(
+    summary: LoggingSummary,
+    event: LoggingEvent,
+    *,
+    status: LoggingStatus = "partial",
+) -> LoggingSummary:
+    updated = summary.model_copy(deep=True)
+    if status == "failed":
+        updated.status = "failed"
+    elif updated.status == "complete":
+        updated.status = status
+    updated.events.append(event)
+    return updated
 
 
 def _summarize_task_usage_rows(
@@ -651,6 +815,115 @@ def _build_validation_summary(*, accuracy: float, episodes: int) -> dict[str, An
         "episodes": episodes,
         "correct": round(accuracy * episodes),
         "accuracy": accuracy,
+    }
+
+
+def _normalize_validation_subscores(value: Any) -> dict[str, float] | None:
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, float] = {}
+    for key, score in value.items():
+        if isinstance(score, int | float) and not isinstance(score, bool):
+            out[str(key)] = float(score)
+    return out
+
+
+def _build_validation_audit_from_detailed(
+    optimized_module: Any,
+    *,
+    episodes: int,
+) -> dict[str, Any] | None:
+    detailed = getattr(optimized_module, "detailed_results", None)
+    if detailed is None:
+        return None
+
+    val_scores = getattr(detailed, "val_aggregate_scores", None)
+    val_subscores = getattr(detailed, "val_subscores", None)
+    best_idx = getattr(detailed, "best_idx", None)
+    discovery = getattr(detailed, "discovery_eval_counts", None)
+    if not isinstance(val_scores, list) or not isinstance(val_subscores, list):
+        return None
+    if not val_scores or not val_subscores or not isinstance(best_idx, int):
+        return None
+    if best_idx < 0 or best_idx >= len(val_scores) or best_idx >= len(val_subscores):
+        return None
+
+    baseline_subscores = _normalize_validation_subscores(val_subscores[0])
+    optimized_subscores = _normalize_validation_subscores(val_subscores[best_idx])
+    baseline_accuracy = (
+        accuracy_from_subscores(baseline_subscores) if baseline_subscores is not None else None
+    )
+    optimized_accuracy = (
+        accuracy_from_subscores(optimized_subscores) if optimized_subscores is not None else None
+    )
+
+    def discovery_count(index: int) -> int | None:
+        if isinstance(discovery, list) and index < len(discovery):
+            value = discovery[index]
+            if isinstance(value, int | float) and not isinstance(value, bool):
+                return int(value)
+        return None
+
+    return {
+        "source": "gepa_detailed_results",
+        "episodes": episodes,
+        "candidate_count": len(val_scores),
+        "best_program_index": best_idx,
+        "baseline": {
+            "program_index": 0,
+            "val_aggregate_score": float(val_scores[0]),
+            "accuracy": baseline_accuracy,
+            "correct": round(baseline_accuracy * episodes)
+            if isinstance(baseline_accuracy, int | float)
+            else None,
+            "discovery_eval_count": discovery_count(0),
+            "subscores": baseline_subscores,
+        },
+        "optimized": {
+            "program_index": best_idx,
+            "val_aggregate_score": float(val_scores[best_idx]),
+            "accuracy": optimized_accuracy,
+            "correct": round(optimized_accuracy * episodes)
+            if isinstance(optimized_accuracy, int | float)
+            else None,
+            "discovery_eval_count": discovery_count(best_idx),
+            "subscores": optimized_subscores,
+        },
+    }
+
+
+def _build_validation_audit_from_result(
+    result: GEPARunResult | None,
+    *,
+    episodes: int,
+    source: str,
+) -> dict[str, Any]:
+    if result is None:
+        return {
+            "source": source,
+            "episodes": episodes,
+            "available": False,
+            "details_available": False,
+            "baseline": None,
+            "optimized": None,
+        }
+
+    return {
+        "source": source,
+        "episodes": episodes,
+        "available": True,
+        "details_available": False,
+        "best_program_index": result.best_program_index,
+        "baseline": {
+            "program_index": 0,
+            "accuracy": result.baseline_accuracy,
+            "correct": round(result.baseline_accuracy * episodes),
+        },
+        "optimized": {
+            "program_index": result.best_program_index,
+            "accuracy": result.final_accuracy,
+            "correct": round(result.final_accuracy * episodes),
+        },
     }
 
 
@@ -904,6 +1177,7 @@ def _run_heldout_eval(
     results: list[GEMEpisodeResult | None] = [None] * total_tasks
     done_count = 0
     timed_out_episodes: list[int] = []
+    failure_records: list[dict[str, Any]] = []
     eval_start = time.monotonic()
     executor = ThreadPoolExecutor(max_workers=max_workers)
     try:
@@ -914,10 +1188,30 @@ def _run_heldout_eval(
         try:
             for future in as_completed(future_to_idx, timeout=total_timeout):
                 idx = future_to_idx[future]
+                task = tasks[idx]
                 try:
                     results[idx] = future.result()
-                except Exception:
+                except Exception as exc:  # noqa: BLE001
+                    import traceback
+
                     logger.exception("Eval episode %d failed", idx)
+                    failure_records.append(
+                        {
+                            "episode_index": task.episode_index,
+                            "seed": task.seed,
+                            "status": "exception",
+                            "timed_out": False,
+                            "error_type": type(exc).__name__,
+                            "error_repr": repr(exc),
+                            "traceback": "".join(
+                                traceback.format_exception(
+                                    type(exc),
+                                    exc,
+                                    exc.__traceback__,
+                                )
+                            ),
+                        }
+                    )
                 done_count += 1
                 elapsed = time.monotonic() - eval_start
                 per_ep = elapsed / done_count
@@ -934,6 +1228,20 @@ def _run_heldout_eval(
                 )
         except TimeoutError:
             timed_out_episodes = [idx for future, idx in future_to_idx.items() if not future.done()]
+            failure_records.extend(
+                {
+                    "episode_index": tasks[idx].episode_index,
+                    "seed": tasks[idx].seed,
+                    "status": "timed_out",
+                    "timed_out": True,
+                    "error_type": "TimeoutError",
+                    "error_repr": (
+                        "Eval episode exceeded the total held-out evaluation timeout "
+                        "window and was canceled."
+                    ),
+                }
+                for idx in timed_out_episodes
+            )
             for future in future_to_idx:
                 future.cancel()
             logger.warning(
@@ -969,15 +1277,20 @@ def _run_heldout_eval(
     total = len(scorable)
     summary = {
         "episodes_attempted": total_tasks,
+        "episodes_completed": len(completed),
+        "episodes_scorable": total,
         "episodes": total,
         "failed": failed,
         "timed_out": len(timed_out_episodes),
         "metrics_unavailable": metrics_unavailable,
         "successes": successes,
         "success_rate": (successes / total) if total else 0.0,
+        "completion_rate": (len(completed) / total_tasks) if total_tasks else 0.0,
+        "attempted_success_rate": (successes / total_tasks) if total_tasks else 0.0,
         "correct": correct,
         "accuracy": (correct / total) if total else 0.0,
         "temperature_eval": config.eval_protocol.temperature_eval,
+        "failure_records": failure_records,
     }
     return (completed, summary)
 
@@ -1258,14 +1571,15 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                 training_rows: list[EpisodeRawMetrics] = []
                 training_usage = _summarize_task_usage_rows([], metrics_unavailable_episodes=0)
                 training_logging_summary = LoggingSummary()
-                reflection_tokens: int | None = 0
-                reflection_cost: float | None = 0.0
+                reflection_usage = _empty_reflection_usage_summary()
+                validation_audit_payload: dict[str, Any] | None = None
                 baseline_eval_results: list[GEMEpisodeResult] = []
                 eval_results: list[GEMEpisodeResult] = []
                 try:
                     # --- Phase 1: GEPA optimization (skip if already done) ---
                     prior_status = _replication_status(replication_dir)
                     prompt_path = replication_dir / "optimized_prompt.txt"
+                    validation_audit_path = replication_dir / "validation_audit.json"
                     resumed_from_gepa_done = prior_status == "gepa_done" and prompt_path.exists()
 
                     if resumed_from_gepa_done:
@@ -1276,6 +1590,7 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             replication_seed,
                         )
                         result = _load_gepa_result(prior_metadata)
+                        validation_audit_payload = _load_json_dict(validation_audit_path)
                         training_rows = _load_training_metrics_rows(replication_dir)
                         training_usage = _summarize_task_usage_rows(
                             training_rows,
@@ -1319,19 +1634,40 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                     )
                                 )
 
-                            saved_reflection_tokens = saved_gepa_phase.get("reflection_tokens")
-                            saved_reflection_cost = saved_gepa_phase.get("reflection_cost")
-                            reflection_tokens = (
-                                int(saved_reflection_tokens)
-                                if isinstance(saved_reflection_tokens, int | float)
-                                else None
-                            )
-                            reflection_cost = (
-                                float(saved_reflection_cost)
-                                if isinstance(saved_reflection_cost, int | float)
-                                else None
-                            )
-                            if reflection_tokens is None or reflection_cost is None:
+                            saved_reflection_usage = saved_gepa_phase.get("reflection_usage")
+                            if isinstance(saved_reflection_usage, dict):
+                                reflection_usage = _coerce_reflection_usage_summary(
+                                    saved_reflection_usage
+                                )
+                            else:
+                                saved_reflection_tokens = saved_gepa_phase.get("reflection_tokens")
+                                saved_reflection_cost = saved_gepa_phase.get("reflection_cost")
+                                if isinstance(saved_reflection_tokens, int | float):
+                                    reflection_usage["total_tokens"] = int(saved_reflection_tokens)
+                                    reflection_usage["known_total_tokens"] = int(
+                                        saved_reflection_tokens
+                                    )
+                                else:
+                                    reflection_usage["total_tokens"] = None
+                                    reflection_usage["token_data_coverage"] = 0.0
+                                if isinstance(saved_reflection_cost, int | float):
+                                    reflection_usage["total_cost_usd"] = float(
+                                        saved_reflection_cost
+                                    )
+                                    reflection_usage["known_cost_usd"] = float(
+                                        saved_reflection_cost
+                                    )
+                                else:
+                                    reflection_usage["total_cost_usd"] = None
+                                    reflection_usage["cost_data_coverage"] = 0.0
+                            if (
+                                saved_reflection_usage is None
+                                and saved_gepa_phase.get("reflection_tokens") is None
+                                and saved_gepa_phase.get("reflection_cost") is None
+                            ) or (
+                                reflection_usage["total_tokens"] is None
+                                or reflection_usage["total_cost_usd"] is None
+                            ):
                                 resume_phase_events.append(
                                     LoggingEvent(
                                         stage="resume",
@@ -1357,8 +1693,14 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                     )
                                 ],
                             )
-                            reflection_tokens = None
-                            reflection_cost = None
+                            reflection_usage = {
+                                "total_tokens": None,
+                                "known_total_tokens": 0,
+                                "token_data_coverage": 0.0,
+                                "total_cost_usd": None,
+                                "known_cost_usd": 0.0,
+                                "cost_data_coverage": 0.0,
+                            }
 
                         if resume_phase_events:
                             training_logging_summary = _merge_logging_summaries(
@@ -1411,8 +1753,12 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         ]
                         training_usage = _summarize_task_usage(training_results)
                         training_logging_summary = _results_logging_summary(training_results)
-                        reflection_tokens, reflection_cost = _extract_reflection_usage(
-                            reflection_lm
+                        reflection_usage = _coerce_reflection_usage_summary(
+                            _extract_reflection_usage(reflection_lm)
+                        )
+                        validation_audit_payload = _build_validation_audit_from_detailed(
+                            optimized_module,
+                            episodes=config.environment.effective_val_size,
                         )
                         _write_csv(
                             replication_dir / "training_metrics.csv",
@@ -1433,12 +1779,9 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         metadata["gepa_phase_summary"] = {
                             "training_usage": training_usage,
                             "logging_summary": training_logging_summary.model_dump(mode="json"),
-                            "reflection_tokens": reflection_tokens,
-                            "reflection_cost": (
-                                round(reflection_cost, _COST_DECIMAL_PLACES)
-                                if isinstance(reflection_cost, int | float)
-                                else None
-                            ),
+                            "reflection_usage": reflection_usage,
+                            "reflection_tokens": reflection_usage["total_tokens"],
+                            "reflection_cost": reflection_usage["total_cost_usd"],
                         }
                         _write_json(replication_dir / "run_metadata.json", metadata)
                         try:
@@ -1453,6 +1796,21 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                                 "update_experiment_run(gepa_done) failed",
                                 exc_info=True,
                             )
+                            training_logging_summary = _append_logging_summary_event(
+                                training_logging_summary,
+                                LoggingEvent(
+                                    stage="publish",
+                                    kind="experiment_run_update_failed",
+                                    message=(
+                                        "Failed to mark the experiment_run record as gepa_done; "
+                                        "local artifacts are still canonical."
+                                    ),
+                                ),
+                            )
+                            metadata["gepa_phase_summary"]["logging_summary"] = (
+                                training_logging_summary.model_dump(mode="json")
+                            )
+                            _write_json(replication_dir / "run_metadata.json", metadata)
                         logger.info(
                             "Saved GEPA artifacts model=%s seed=%s",
                             task_model.name,
@@ -1476,25 +1834,57 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
 
                     # --- Phase 2: Held-out evaluation ---
                     logger.info("Running baseline eval with seed prompt...")
-                    baseline_eval_results, baseline_eval_summary = _run_heldout_eval(
+                    baseline_eval_results, baseline_eval_summary_raw = _run_heldout_eval(
                         config=config,
                         task_model_id=model_id,
                         instructions=seed_prompt,
                         experiment_run_id=exp_run_id,
                     )
+                    baseline_eval_summary, baseline_eval_failures = _split_eval_summary_artifacts(
+                        baseline_eval_summary_raw
+                    )
 
                     logger.info("Running optimized eval...")
-                    eval_results, eval_summary = _run_heldout_eval(
+                    eval_results, eval_summary_raw = _run_heldout_eval(
                         config=config,
                         task_model_id=model_id,
                         instructions=optimized_prompt,
                         experiment_run_id=exp_run_id,
                     )
+                    eval_summary, optimized_eval_failures = _split_eval_summary_artifacts(
+                        eval_summary_raw
+                    )
 
                     heldout_results = baseline_eval_results + eval_results
+                    eval_failure_manifest_name = "eval_failure_manifest.jsonl"
+                    eval_failure_records = [
+                        {"phase": "baseline", **record} for record in baseline_eval_failures
+                    ] + [{"phase": "optimized", **record} for record in optimized_eval_failures]
+                    _write_jsonl_records(
+                        replication_dir / eval_failure_manifest_name,
+                        eval_failure_records,
+                    )
                     heldout_logging_summary = _results_logging_summary(heldout_results)
+                    eval_failure_logging_summary = _merge_logging_summaries(
+                        [
+                            _build_eval_failure_logging_summary(
+                                phase="baseline",
+                                failure_records=baseline_eval_failures,
+                                manifest_name=eval_failure_manifest_name,
+                            ),
+                            _build_eval_failure_logging_summary(
+                                phase="optimized",
+                                failure_records=optimized_eval_failures,
+                                manifest_name=eval_failure_manifest_name,
+                            ),
+                        ]
+                    )
                     logging_summary = _merge_logging_summaries(
-                        [training_logging_summary, heldout_logging_summary]
+                        [
+                            training_logging_summary,
+                            heldout_logging_summary,
+                            eval_failure_logging_summary,
+                        ]
                     )
                     val_total = config.environment.effective_val_size
                     baseline_validation_summary: dict[str, Any] | None = None
@@ -1508,6 +1898,18 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             accuracy=result.final_accuracy,
                             episodes=val_total,
                         )
+                    if validation_audit_payload is None:
+                        validation_audit_source = (
+                            "resume_saved_result"
+                            if resumed_from_gepa_done
+                            else "result_summary_only"
+                        )
+                        validation_audit_payload = _build_validation_audit_from_result(
+                            result,
+                            episodes=val_total,
+                            source=validation_audit_source,
+                        )
+                    _write_json(validation_audit_path, validation_audit_payload)
                     heldout_rows = [
                         result.raw_metrics
                         for result in heldout_results
@@ -1522,8 +1924,17 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             "baseline_eval": _raw_metrics_summary_for_results(
                                 baseline_eval_results
                             ),
+                            "baseline_eval_denominators": baseline_eval_summary,
                             "optimized_eval": _raw_metrics_summary_for_results(eval_results),
+                            "optimized_eval_denominators": eval_summary,
                             "heldout_total": _raw_metrics_summary_for_results(heldout_results),
+                            "heldout_total_denominators": _merge_eval_outcome_summaries(
+                                [baseline_eval_summary, eval_summary]
+                            ),
+                            "eval_failure_manifest": {
+                                "path": eval_failure_manifest_name,
+                                "count": len(eval_failure_records),
+                            },
                         },
                     )
 
@@ -1547,17 +1958,27 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         if isinstance(task_cost_known_value, int | float)
                         else 0.0
                     )
+                    reflection_tokens = reflection_usage["total_tokens"]
+                    reflection_tokens_known_value = reflection_usage["known_total_tokens"]
+                    reflection_tokens_known = (
+                        int(reflection_tokens_known_value)
+                        if isinstance(reflection_tokens_known_value, int | float)
+                        else 0
+                    )
+                    reflection_cost = reflection_usage["total_cost_usd"]
+                    reflection_cost_known_value = reflection_usage["known_cost_usd"]
+                    reflection_cost_known = (
+                        float(reflection_cost_known_value)
+                        if isinstance(reflection_cost_known_value, int | float)
+                        else 0.0
+                    )
                     total_tokens = (
                         int(task_tokens) + reflection_tokens
                         if isinstance(task_tokens, int) and isinstance(reflection_tokens, int)
                         else None
                     )
-                    total_tokens_known = task_tokens_known + (
-                        reflection_tokens if isinstance(reflection_tokens, int) else 0
-                    )
-                    total_cost_known = task_cost_known + (
-                        reflection_cost if isinstance(reflection_cost, int | float) else 0.0
-                    )
+                    total_tokens_known = task_tokens_known + reflection_tokens_known
+                    total_cost_known = task_cost_known + reflection_cost_known
                     total_cost = (
                         round(total_cost_known, _COST_DECIMAL_PLACES)
                         if isinstance(task_cost, int | float)
@@ -1583,11 +2004,11 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         "task_model_cost_known": round(task_cost_known, _COST_DECIMAL_PLACES),
                         "task_model_cost_data_coverage": task_usage["cost_data_coverage"],
                         "reflection_tokens": reflection_tokens,
-                        "reflection_cost": (
-                            round(reflection_cost, _COST_DECIMAL_PLACES)
-                            if isinstance(reflection_cost, int | float)
-                            else None
-                        ),
+                        "reflection_tokens_known": reflection_tokens_known,
+                        "reflection_token_data_coverage": reflection_usage["token_data_coverage"],
+                        "reflection_cost": reflection_cost,
+                        "reflection_cost_known": round(reflection_cost_known, _COST_DECIMAL_PLACES),
+                        "reflection_cost_data_coverage": reflection_usage["cost_data_coverage"],
                         "total_tokens": total_tokens,
                         "total_tokens_known": total_tokens_known,
                         "total_cost": total_cost,
@@ -1671,6 +2092,44 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             )
 
                     finished = _utc_now()
+                    run_report_payload: dict[str, Any] | None = None
+                    try:
+                        run_report = build_run_report(
+                            experiment_run_id=exp_run_id,
+                            db_path=_DB_PATH,
+                            cost_summary=cost_summary,
+                            baseline_validation_summary=baseline_validation_summary,
+                            optimized_validation_summary=optimized_validation_summary,
+                            baseline_eval_summary=baseline_eval_summary,
+                            eval_summary=eval_summary,
+                            wall_clock_seconds=round((finished - started_at).total_seconds(), 3),
+                            reference_prices=settings.cost_normalization.reference_prices,
+                            prompt_token_ratio=settings.cost_normalization.prompt_token_ratio,
+                            logging_summary=logging_summary.model_dump(mode="json"),
+                        )
+                        run_report_payload = cast(
+                            dict[str, Any],
+                            json.loads(run_report.model_dump_json()),
+                        )
+                        _write_json(replication_dir / "run_report.json", run_report_payload)
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "Failed to generate run report for %s",
+                            exp_run_id,
+                            exc_info=True,
+                        )
+                        logging_summary = _append_logging_summary_event(
+                            logging_summary,
+                            LoggingEvent(
+                                stage="publish",
+                                kind="run_report_failed",
+                                message=(
+                                    "Failed to generate run_report.json; run_metadata.json "
+                                    "and cost_summary.json remain canonical."
+                                ),
+                            ),
+                        )
+
                     metadata["logging_summary"] = logging_summary.model_dump(mode="json")
                     metadata.update(
                         {
@@ -1704,32 +2163,22 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             "update_experiment_run(completed) failed",
                             exc_info=True,
                         )
-
-                    # Generate unified run report.
-                    try:
-                        run_report = build_run_report(
-                            experiment_run_id=exp_run_id,
-                            db_path=_DB_PATH,
-                            cost_summary=cost_summary,
-                            baseline_validation_summary=baseline_validation_summary,
-                            optimized_validation_summary=optimized_validation_summary,
-                            baseline_eval_summary=baseline_eval_summary,
-                            eval_summary=eval_summary,
-                            wall_clock_seconds=round((finished - started_at).total_seconds(), 3),
-                            reference_prices=settings.cost_normalization.reference_prices,
-                            prompt_token_ratio=settings.cost_normalization.prompt_token_ratio,
-                            logging_summary=logging_summary.model_dump(mode="json"),
+                        logging_summary = _append_logging_summary_event(
+                            logging_summary,
+                            LoggingEvent(
+                                stage="publish",
+                                kind="experiment_run_update_failed",
+                                message=(
+                                    "Failed to update the experiment_run record to completed; "
+                                    "local result artifacts remain canonical."
+                                ),
+                            ),
                         )
-                        _write_json(
-                            replication_dir / "run_report.json",
-                            json.loads(run_report.model_dump_json()),
-                        )
-                    except Exception:  # noqa: BLE001
-                        logger.warning(
-                            "Failed to generate run report for %s",
-                            exp_run_id,
-                            exc_info=True,
-                        )
+                        metadata["logging_summary"] = logging_summary.model_dump(mode="json")
+                        _write_json(replication_dir / "run_metadata.json", metadata)
+                        if run_report_payload is not None:
+                            run_report_payload["logging_summary"] = metadata["logging_summary"]
+                            _write_json(replication_dir / "run_report.json", run_report_payload)
 
                     model_entries[str(replication_seed)] = {
                         "status": "completed",
@@ -1773,6 +2222,8 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                     eval_acc = eval_summary["accuracy"]
                     eval_correct = eval_summary["correct"]
                     eval_total = eval_summary["episodes"]
+                    baseline_eval_details = _format_eval_detail_line(baseline_eval_summary)
+                    eval_details = _format_eval_detail_line(eval_summary)
                     total_cost_display = (
                         f"${total_cost:.4f}"
                         if isinstance(total_cost, int | float)
@@ -1789,8 +2240,10 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                         f"{validation_lines}"
                         f"  Test/eval: Baseline accuracy:  {bl_eval_acc:.1%} "
                         f"({bl_eval_correct}/{bl_eval_total}) ({eval_bench})\n"
+                        f"  Test/eval details:  Baseline {baseline_eval_details}\n"
                         f"  Test/eval: Optimized accuracy: {eval_acc:.1%} "
                         f"({eval_correct}/{eval_total}) ({eval_bench})\n"
+                        f"  Test/eval details:  Optimized {eval_details}\n"
                         f"  Total cost:         {total_cost_display}\n"
                         f"  Total tokens:       {total_tokens_display}\n"
                         f"  Elapsed:            {(finished - started_at).total_seconds():.1f}s\n"
@@ -1799,10 +2252,62 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                     )
                 except Exception as exc:
                     finished = _utc_now()
+                    salvage_events: list[LoggingEvent] = []
+                    if not training_results and getattr(runner, "episode_history", ()):
+                        try:
+                            training_results = _persist_training_trajectories(
+                                list(runner.episode_history),
+                                experiment_run_id=exp_run_id,
+                            )
+                            training_rows = [
+                                episode.raw_metrics
+                                for episode in training_results
+                                if episode.raw_metrics is not None
+                            ]
+                            if training_rows:
+                                _write_csv(replication_dir / "training_metrics.csv", training_rows)
+                                _write_jsonl(
+                                    replication_dir / "training_metrics.jsonl",
+                                    training_rows,
+                                )
+                                _write_json(
+                                    replication_dir / "training_metrics_summary.json",
+                                    _raw_metrics_summary_for_results(training_results),
+                                )
+                            training_logging_summary = _merge_logging_summaries(
+                                [
+                                    training_logging_summary,
+                                    _results_logging_summary(training_results),
+                                ]
+                            )
+                            salvage_events.append(
+                                LoggingEvent(
+                                    stage="gepa",
+                                    kind="training_trajectories_salvaged",
+                                    message=(
+                                        "Persisted partial GEPA training trajectories after a "
+                                        "replication failure for postmortem analysis."
+                                    ),
+                                )
+                            )
+                        except Exception as salvage_exc:  # noqa: BLE001
+                            salvage_events.append(
+                                LoggingEvent(
+                                    stage="gepa",
+                                    kind="training_trajectory_salvage_failed",
+                                    message=(
+                                        "Failed to salvage partial GEPA training trajectories "
+                                        f"after replication failure: {salvage_exc!r}"
+                                    ),
+                                )
+                            )
                     partial_logging_summary = _merge_logging_summaries(
                         [
                             training_logging_summary,
                             _results_logging_summary(baseline_eval_results + eval_results),
+                            LoggingSummary(status="partial", events=salvage_events)
+                            if salvage_events
+                            else LoggingSummary(),
                         ]
                     )
                     metadata.update(
@@ -1829,6 +2334,21 @@ def run_experiment(args: RunExperimentArgs) -> dict[str, Any]:
                             "update_experiment_run(failed) failed",
                             exc_info=True,
                         )
+                        partial_logging_summary = _append_logging_summary_event(
+                            partial_logging_summary,
+                            LoggingEvent(
+                                stage="publish",
+                                kind="experiment_run_update_failed",
+                                message=(
+                                    "Failed to update the experiment_run record with failed "
+                                    "status; local run_metadata.json remains canonical."
+                                ),
+                            ),
+                        )
+                        metadata["logging_summary"] = partial_logging_summary.model_dump(
+                            mode="json"
+                        )
+                        _write_json(replication_dir / "run_metadata.json", metadata)
                     model_entries[str(replication_seed)] = {
                         "status": "failed",
                         "experiment_run_id": exp_run_id,

--- a/src/trajectory_aware_gym/metrics/raw_metrics.py
+++ b/src/trajectory_aware_gym/metrics/raw_metrics.py
@@ -175,9 +175,9 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
     total_token_values: list[int] = []
     llm_latency_values: list[float] = []
 
-    cost_seen_steps = 0.0
-    token_seen_steps = 0.0
-    latency_seen_steps = 0.0
+    cost_coverage_sum = 0.0
+    token_coverage_sum = 0.0
+    latency_coverage_sum = 0.0
 
     for step in trajectory.steps:
         info: Mapping[str, Any] = step.info if isinstance(step.info, Mapping) else {}
@@ -219,7 +219,7 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
 
         if step_cost is not None:
             cost_values.append(step_cost)
-        cost_seen_steps += step_cost_coverage
+        cost_coverage_sum += step_cost_coverage
 
         if (
             step_total_tokens is None
@@ -234,11 +234,11 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
             completion_token_values.append(step_completion_tokens)
         if step_total_tokens is not None:
             total_token_values.append(step_total_tokens)
-        token_seen_steps += step_token_coverage
+        token_coverage_sum += step_token_coverage
 
         if step_llm_latency is not None:
             llm_latency_values.append(step_llm_latency)
-        latency_seen_steps += step_latency_coverage
+        latency_coverage_sum += step_latency_coverage
 
     # Aggregate raw cost and token totals.
     llm_cost_usd = sum(cost_values) if cost_values else None
@@ -296,9 +296,9 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
         cost_per_step_usd=cost_per_step_usd,
         cost_per_success_usd=cost_per_success_usd,
         tokens_per_step=tokens_per_step,
-        cost_data_coverage=cost_seen_steps / denominator,
-        token_data_coverage=token_seen_steps / denominator,
-        llm_latency_data_coverage=latency_seen_steps / denominator,
+        cost_data_coverage=cost_coverage_sum / denominator,
+        token_data_coverage=token_coverage_sum / denominator,
+        llm_latency_data_coverage=latency_coverage_sum / denominator,
     )
 
 

--- a/src/trajectory_aware_gym/metrics/raw_metrics.py
+++ b/src/trajectory_aware_gym/metrics/raw_metrics.py
@@ -175,9 +175,9 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
     total_token_values: list[int] = []
     llm_latency_values: list[float] = []
 
-    cost_seen_steps = 0
-    token_seen_steps = 0
-    latency_seen_steps = 0
+    cost_seen_steps = 0.0
+    token_seen_steps = 0.0
+    latency_seen_steps = 0.0
 
     for step in trajectory.steps:
         info: Mapping[str, Any] = step.info if isinstance(step.info, Mapping) else {}
@@ -188,30 +188,43 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
         step_completion_tokens = _extract_int(info, _COMPLETION_TOKEN_PATHS)
         step_total_tokens = _extract_int(info, _TOTAL_TOKEN_PATHS)
         step_llm_latency = _extract_numeric(info, _LATENCY_PATHS)
+        step_cost_coverage = 1.0 if step_cost is not None else 0.0
+        token_info_complete = step_total_tokens is not None or (
+            step_prompt_tokens is not None and step_completion_tokens is not None
+        )
+        step_token_coverage = 1.0 if token_info_complete else 0.0
+        step_latency_coverage = 1.0 if step_llm_latency is not None else 0.0
 
         # Fall back to step.llm_calls when info dict has no data.
-        if step.llm_calls and step_total_tokens is None and step_prompt_tokens is None:
-            step_prompt_tokens = sum(c.prompt_tokens for c in step.llm_calls)
-            step_completion_tokens = sum(c.completion_tokens for c in step.llm_calls)
-            step_total_tokens = sum(c.total_tokens for c in step.llm_calls)
+        if step.llm_calls and not token_info_complete:
+            known_token_calls = [c for c in step.llm_calls if c.token_usage_known]
+            if known_token_calls:
+                step_prompt_tokens = sum(c.prompt_tokens for c in known_token_calls)
+                step_completion_tokens = sum(c.completion_tokens for c in known_token_calls)
+                step_total_tokens = sum(c.total_tokens for c in known_token_calls)
+            step_token_coverage = len(known_token_calls) / len(step.llm_calls)
 
         if step.llm_calls and step_cost is None:
             calls_with_cost = [c.cost_usd for c in step.llm_calls if c.cost_usd is not None]
             if calls_with_cost:
                 step_cost = sum(calls_with_cost)
+            step_cost_coverage = len(calls_with_cost) / len(step.llm_calls)
 
         if step.llm_calls and step_llm_latency is None:
             calls_with_latency = [c.latency_ms for c in step.llm_calls if c.latency_ms is not None]
             if calls_with_latency:
                 # Sum gives total LLM wall-clock per step (calls are sequential).
                 step_llm_latency = sum(calls_with_latency) / 1000.0
+            step_latency_coverage = len(calls_with_latency) / len(step.llm_calls)
 
         if step_cost is not None:
             cost_values.append(step_cost)
-            cost_seen_steps += 1
+        cost_seen_steps += step_cost_coverage
 
-        if step_total_tokens is None and (
-            step_prompt_tokens is not None or step_completion_tokens is not None
+        if (
+            step_total_tokens is None
+            and step_prompt_tokens is not None
+            and step_completion_tokens is not None
         ):
             step_total_tokens = (step_prompt_tokens or 0) + (step_completion_tokens or 0)
 
@@ -221,17 +234,11 @@ def extract_episode_raw_metrics(trajectory: TrajectoryLog) -> EpisodeRawMetrics:
             completion_token_values.append(step_completion_tokens)
         if step_total_tokens is not None:
             total_token_values.append(step_total_tokens)
-
-        if (
-            step_prompt_tokens is not None
-            or step_completion_tokens is not None
-            or step_total_tokens is not None
-        ):
-            token_seen_steps += 1
+        token_seen_steps += step_token_coverage
 
         if step_llm_latency is not None:
             llm_latency_values.append(step_llm_latency)
-            latency_seen_steps += 1
+        latency_seen_steps += step_latency_coverage
 
     # Aggregate raw cost and token totals.
     llm_cost_usd = sum(cost_values) if cost_values else None

--- a/src/trajectory_aware_gym/metrics/run_report.py
+++ b/src/trajectory_aware_gym/metrics/run_report.py
@@ -45,11 +45,16 @@ class RunReport(BaseModel):
     # Cost — actual (Bedrock) or unavailable (Ollama)
     total_tokens: int | None = None
     total_tokens_known: int | None = None
+    reflection_tokens: int | None = None
+    reflection_tokens_known: int | None = None
+    reflection_token_data_coverage: float | None = None
     task_model_cost_usd: float | None = None
     task_model_cost_known_usd: float | None = None
     task_model_token_data_coverage: float | None = None
     task_model_cost_data_coverage: float | None = None
     reflection_cost_usd: float | None = None
+    reflection_cost_known_usd: float | None = None
+    reflection_cost_data_coverage: float | None = None
     total_cost_usd: float | None = None
     total_cost_known_usd: float | None = None
     cost_type: RunReportCostType | None = None
@@ -94,13 +99,21 @@ def build_run_report(
     task_model_cost = cost_summary.get("task_model_cost")
     task_model_cost_known = cost_summary.get("task_model_cost_known", task_model_cost)
     reflection_cost = cost_summary.get("reflection_cost")
+    reflection_cost_known = cost_summary.get("reflection_cost_known", reflection_cost)
     total_cost = cost_summary.get("total_cost")
     total_cost_known = cost_summary.get("total_cost_known", total_cost)
     total_tokens = cost_summary.get("total_tokens")
     total_tokens_known = cost_summary.get("total_tokens_known", total_tokens)
     task_tokens = cost_summary.get("task_model_tokens")
+    reflection_tokens = cost_summary.get("reflection_tokens")
+    reflection_tokens_known = cost_summary.get(
+        "reflection_tokens_known",
+        reflection_tokens,
+    )
     task_token_coverage = cost_summary.get("task_model_token_data_coverage")
     task_cost_coverage = cost_summary.get("task_model_cost_data_coverage")
+    reflection_token_coverage = cost_summary.get("reflection_token_data_coverage")
+    reflection_cost_coverage = cost_summary.get("reflection_cost_data_coverage")
 
     # Determine cost type and compute normalized cost for Ollama models.
     raw_cost_type = cost_summary.get("cost_type")
@@ -170,11 +183,16 @@ def build_run_report(
         eval_summary=eval_summary,
         total_tokens=total_tokens,
         total_tokens_known=total_tokens_known,
+        reflection_tokens=reflection_tokens,
+        reflection_tokens_known=reflection_tokens_known,
+        reflection_token_data_coverage=reflection_token_coverage,
         task_model_cost_usd=task_model_cost,
         task_model_cost_known_usd=task_model_cost_known,
         task_model_token_data_coverage=task_token_coverage,
         task_model_cost_data_coverage=task_cost_coverage,
         reflection_cost_usd=reflection_cost,
+        reflection_cost_known_usd=reflection_cost_known,
+        reflection_cost_data_coverage=reflection_cost_coverage,
         total_cost_usd=total_cost,
         total_cost_known_usd=total_cost_known,
         cost_type=cost_type,

--- a/src/trajectory_aware_gym/metrics/run_report.py
+++ b/src/trajectory_aware_gym/metrics/run_report.py
@@ -87,12 +87,15 @@ def build_run_report(
     reference_prices: dict[str, dict[str, float]] | None = None,
     prompt_token_ratio: float | None = None,
     logging_summary: dict[str, Any] | None = None,
+    finished_at: str | None = None,
 ) -> RunReport:
     """Assemble a RunReport from DB record + caller-provided summaries.
 
     The caller passes ``cost_summary``, ``eval_summary``, etc. because
     these are already computed in the runner and do not need to be
-    re-derived from raw episode data.
+    re-derived from raw episode data. ``finished_at`` may be provided by
+    the runner so the report can reflect completion even before the DB row
+    is updated from ``running`` to ``completed``.
     """
     run = load_experiment_run(db_path, experiment_run_id)
 
@@ -202,7 +205,11 @@ def build_run_report(
         mean_llm_latency_ms=mean_latency,
         git_commit=run.git_commit,
         started_at=run.started_at.isoformat() if run.started_at else None,
-        finished_at=run.finished_at.isoformat() if run.finished_at else None,
+        finished_at=finished_at
+        if finished_at is not None
+        else run.finished_at.isoformat()
+        if run.finished_at
+        else None,
         logging_summary=(
             logging_summary
             if logging_summary is not None

--- a/src/trajectory_aware_gym/models/gepa_result.py
+++ b/src/trajectory_aware_gym/models/gepa_result.py
@@ -18,6 +18,16 @@ def accuracy_from_subscores(subscores: dict) -> float:
     return sum(1 for s in subscores.values() if s > 0) / len(subscores)
 
 
+def _normalize_validation_subscores(value: Any) -> dict[str, float] | None:
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, float] = {}
+    for key, score in value.items():
+        if isinstance(score, int | float) and not isinstance(score, bool):
+            out[str(key)] = float(score)
+    return out
+
+
 class GEPARunResult(BaseModel, frozen=True):
     """Structured summary of a GEPA optimization run."""
 
@@ -47,3 +57,113 @@ class GEPARunResult(BaseModel, frozen=True):
             best_program_index=best_idx,
             optimized_instructions=getattr(module, "instructions", seed_prompt),
         )
+
+
+def build_validation_audit_from_detailed(
+    optimized_module: Any,
+    *,
+    episodes: int,
+) -> dict[str, Any] | None:
+    """Extract a validation-audit payload from an optimized module's `detailed_results`.
+
+    Returns `None` when the module has no GEPA detail or when the detail is
+    malformed in a way that makes baseline vs. best comparison unsound.
+    """
+    detailed = getattr(optimized_module, "detailed_results", None)
+    if detailed is None:
+        return None
+
+    val_scores = getattr(detailed, "val_aggregate_scores", None)
+    val_subscores = getattr(detailed, "val_subscores", None)
+    best_idx = getattr(detailed, "best_idx", None)
+    discovery = getattr(detailed, "discovery_eval_counts", None)
+    if not isinstance(val_scores, list) or not isinstance(val_subscores, list):
+        return None
+    if not val_scores or not val_subscores or not isinstance(best_idx, int):
+        return None
+    if best_idx < 0 or best_idx >= len(val_scores) or best_idx >= len(val_subscores):
+        return None
+
+    baseline_subscores = _normalize_validation_subscores(val_subscores[0])
+    optimized_subscores = _normalize_validation_subscores(val_subscores[best_idx])
+    baseline_accuracy = (
+        accuracy_from_subscores(baseline_subscores) if baseline_subscores is not None else None
+    )
+    optimized_accuracy = (
+        accuracy_from_subscores(optimized_subscores) if optimized_subscores is not None else None
+    )
+
+    def discovery_count(index: int) -> int | None:
+        if isinstance(discovery, list) and index < len(discovery):
+            value = discovery[index]
+            if isinstance(value, int | float) and not isinstance(value, bool):
+                return int(value)
+        return None
+
+    return {
+        "source": "gepa_detailed_results",
+        "episodes": episodes,
+        "candidate_count": len(val_scores),
+        "best_program_index": best_idx,
+        "baseline": {
+            "program_index": 0,
+            "val_aggregate_score": float(val_scores[0]),
+            "accuracy": baseline_accuracy,
+            "correct": round(baseline_accuracy * episodes)
+            if isinstance(baseline_accuracy, int | float)
+            else None,
+            "discovery_eval_count": discovery_count(0),
+            "subscores": baseline_subscores,
+        },
+        "optimized": {
+            "program_index": best_idx,
+            "val_aggregate_score": float(val_scores[best_idx]),
+            "accuracy": optimized_accuracy,
+            "correct": round(optimized_accuracy * episodes)
+            if isinstance(optimized_accuracy, int | float)
+            else None,
+            "discovery_eval_count": discovery_count(best_idx),
+            "subscores": optimized_subscores,
+        },
+    }
+
+
+def build_validation_audit_from_result(
+    result: GEPARunResult | None,
+    *,
+    episodes: int,
+    source: str,
+) -> dict[str, Any]:
+    """Fallback audit payload when only a `GEPARunResult` summary is available.
+
+    Used on resume from a saved `gepa_done` checkpoint where the full GEPA
+    detailed_results are not reconstructable; marks `details_available=False`
+    so downstream consumers know subscore-level evidence is missing.
+    """
+    if result is None:
+        return {
+            "source": source,
+            "episodes": episodes,
+            "available": False,
+            "details_available": False,
+            "baseline": None,
+            "optimized": None,
+        }
+
+    return {
+        "source": source,
+        "episodes": episodes,
+        "available": True,
+        "details_available": False,
+        "best_program_index": result.best_program_index,
+        "baseline": {
+            "program_index": 0,
+            "accuracy": result.baseline_accuracy,
+            "correct": round(result.baseline_accuracy * episodes),
+        },
+        "optimized": {
+            "program_index": result.best_program_index,
+            "accuracy": result.final_accuracy,
+            "correct": round(result.final_accuracy * episodes),
+        },
+    }

--- a/src/trajectory_aware_gym/models/reflection_usage.py
+++ b/src/trajectory_aware_gym/models/reflection_usage.py
@@ -1,0 +1,93 @@
+"""Typed summary of reflection-LM token and cost usage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+_COST_DECIMAL_PLACES = 6
+
+
+class ReflectionUsageSummary(BaseModel, frozen=True):
+    """Reflection-LM usage with explicit known-vs-unknown accounting.
+
+    `total_tokens` / `total_cost_usd` are `None` when coverage is partial;
+    `known_*` fields always carry the sum over entries that did report data.
+    Data-coverage fields are fractions in `[0, 1]`.
+    """
+
+    total_tokens: int | None = None
+    known_total_tokens: int = Field(default=0, ge=0)
+    token_data_coverage: float = Field(default=1.0, ge=0.0, le=1.0)
+    total_cost_usd: float | None = None
+    known_cost_usd: float = Field(default=0.0, ge=0.0)
+    cost_data_coverage: float = Field(default=1.0, ge=0.0, le=1.0)
+
+    @classmethod
+    def empty(cls) -> ReflectionUsageSummary:
+        """Summary for `reflection_lm=None` — nothing to measure, fully accounted."""
+        return cls(
+            total_tokens=0,
+            known_total_tokens=0,
+            token_data_coverage=1.0,
+            total_cost_usd=0.0,
+            known_cost_usd=0.0,
+            cost_data_coverage=1.0,
+        )
+
+    @classmethod
+    def from_saved(cls, payload: Any) -> ReflectionUsageSummary:
+        """Reconstruct from a previously serialized `reflection_usage` dict.
+
+        Missing fields fall back to the empty-summary defaults. Unknown keys are
+        ignored. Returns an empty summary when `payload` is not a dict.
+        """
+        if not isinstance(payload, dict):
+            return cls.empty()
+        merged = cls.empty().model_dump()
+        for key, value in payload.items():
+            if key in merged:
+                merged[key] = value
+        return cls.model_validate(merged)
+
+    @classmethod
+    def from_history(cls, entries: list[dict[str, Any]]) -> ReflectionUsageSummary:
+        """Build from per-call LM history, recording fractional coverage of missing usage/cost.
+
+        Entries without numeric `usage.total_tokens` are counted as unknown tokens;
+        entries whose `response` can't be costed are counted as unknown cost. When
+        coverage is 1.0 the respective `total_*` field is populated; otherwise it
+        remains `None` and only the `known_*` running sum is reported.
+        """
+        if not entries:
+            return cls.empty()
+
+        known_total_tokens = 0
+        token_known_entries = 0
+        known_cost_usd = 0.0
+        cost_known_entries = 0
+
+        for entry in entries:
+            usage_total = entry.get("usage_total_tokens")
+            if isinstance(usage_total, int | float) and not isinstance(usage_total, bool):
+                known_total_tokens += int(usage_total)
+                token_known_entries += 1
+
+            entry_cost = entry.get("cost_usd")
+            if isinstance(entry_cost, int | float) and not isinstance(entry_cost, bool):
+                known_cost_usd += float(entry_cost)
+                cost_known_entries += 1
+
+        token_coverage = token_known_entries / len(entries)
+        cost_coverage = cost_known_entries / len(entries)
+        return cls(
+            total_tokens=known_total_tokens if token_coverage == 1.0 else None,
+            known_total_tokens=known_total_tokens,
+            token_data_coverage=token_coverage,
+            total_cost_usd=(
+                round(known_cost_usd, _COST_DECIMAL_PLACES) if cost_coverage == 1.0 else None
+            ),
+            known_cost_usd=round(known_cost_usd, _COST_DECIMAL_PLACES),
+            cost_data_coverage=cost_coverage,
+        )

--- a/src/trajectory_aware_gym/storage/trajectory_db.py
+++ b/src/trajectory_aware_gym/storage/trajectory_db.py
@@ -260,7 +260,7 @@ def _migrate_existing_schema(conn: sqlite3.Connection) -> None:
             "provider": "ALTER TABLE llm_calls ADD COLUMN provider TEXT",
             "cost_type": "ALTER TABLE llm_calls ADD COLUMN cost_type TEXT",
             "latency_ms": "ALTER TABLE llm_calls ADD COLUMN latency_ms REAL",
-            "token_usage_known": (
+            "token_usage_known": (  # nosec B105 — column name, not a password
                 "ALTER TABLE llm_calls ADD COLUMN token_usage_known INTEGER NOT NULL DEFAULT 1"
             ),
         },

--- a/src/trajectory_aware_gym/storage/trajectory_db.py
+++ b/src/trajectory_aware_gym/storage/trajectory_db.py
@@ -105,6 +105,7 @@ CREATE TABLE IF NOT EXISTS llm_calls (
     prompt_tokens     INTEGER NOT NULL,
     completion_tokens INTEGER NOT NULL,
     total_tokens      INTEGER NOT NULL,
+    token_usage_known INTEGER NOT NULL DEFAULT 1,
     cost_usd          REAL,
     cost_type         TEXT,
     latency_ms        REAL,
@@ -259,6 +260,9 @@ def _migrate_existing_schema(conn: sqlite3.Connection) -> None:
             "provider": "ALTER TABLE llm_calls ADD COLUMN provider TEXT",
             "cost_type": "ALTER TABLE llm_calls ADD COLUMN cost_type TEXT",
             "latency_ms": "ALTER TABLE llm_calls ADD COLUMN latency_ms REAL",
+            "token_usage_known": (
+                "ALTER TABLE llm_calls ADD COLUMN token_usage_known INTEGER NOT NULL DEFAULT 1"
+            ),
         },
         "tool_calls": {
             "duration_ms": "ALTER TABLE tool_calls ADD COLUMN duration_ms REAL",
@@ -435,9 +439,9 @@ def save_trajectory(
                         """
                         INSERT INTO llm_calls
                             (run_id, step_index, model_id, provider, prompt_tokens,
-                             completion_tokens, total_tokens, cost_usd, cost_type,
-                             latency_ms)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                             completion_tokens, total_tokens, token_usage_known,
+                             cost_usd, cost_type, latency_ms)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         [
                             (
@@ -448,6 +452,7 @@ def save_trajectory(
                                 lc.prompt_tokens,
                                 lc.completion_tokens,
                                 lc.total_tokens,
+                                int(lc.token_usage_known),
                                 lc.cost_usd,
                                 lc.cost_type,
                                 lc.latency_ms,
@@ -518,6 +523,9 @@ def _build_trajectory(
                 prompt_tokens=row["prompt_tokens"],
                 completion_tokens=row["completion_tokens"],
                 total_tokens=row["total_tokens"],
+                token_usage_known=(
+                    bool(row["token_usage_known"]) if "token_usage_known" in row.keys() else True
+                ),
                 cost_usd=row["cost_usd"],
                 cost_type=row["cost_type"] if "cost_type" in row.keys() else None,
                 latency_ms=row["latency_ms"],

--- a/tests/unit/test_experiment_runner.py
+++ b/tests/unit/test_experiment_runner.py
@@ -26,6 +26,7 @@ from trajectory_aware_gym.experiments.runner import (
     _extract_pareto_frontier,
     _extract_reflection_usage,
     _find_resumable_run,
+    _format_eval_detail_line,
     _is_replication_completed,
     _model_replication_dir,
     _persist_training_trajectories,
@@ -355,6 +356,8 @@ def test_run_experiment_writes_full_replication_artifacts(
     assert (replication_dir / "raw_metrics.csv").exists()
     assert (replication_dir / "raw_metrics.jsonl").exists()
     assert (replication_dir / "raw_metrics_summary.json").exists()
+    assert (replication_dir / "validation_audit.json").exists()
+    assert (replication_dir / "eval_failure_manifest.jsonl").exists()
     assert (replication_dir / "gepa_logs").is_dir()
 
     cost_summary = json.loads((replication_dir / "cost_summary.json").read_text(encoding="utf-8"))
@@ -397,12 +400,24 @@ def test_run_experiment_writes_full_replication_artifacts(
     assert raw_summary["scope"] == "heldout_eval"
     assert raw_summary["baseline_eval"]["episodes"] == 1
     assert raw_summary["baseline_eval"]["successes"] == 1
+    assert raw_summary["baseline_eval_denominators"]["episodes_attempted"] == 1
     assert raw_summary["optimized_eval"]["episodes"] == 1
     assert raw_summary["optimized_eval"]["successes"] == 1
+    assert raw_summary["optimized_eval_denominators"]["episodes_completed"] == 1
     assert raw_summary["heldout_total"]["episodes"] == 2
     assert raw_summary["heldout_total"]["successes"] == 2
+    assert raw_summary["heldout_total_denominators"]["episodes_attempted"] == 2
+    assert raw_summary["eval_failure_manifest"]["count"] == 0
     assert raw_summary["heldout_total"]["mean_cost_data_coverage"] > 0
     assert raw_summary["heldout_total"]["mean_token_data_coverage"] > 0
+
+    validation_audit = json.loads(
+        (replication_dir / "validation_audit.json").read_text(encoding="utf-8")
+    )
+    assert validation_audit["source"] == "gepa_detailed_results"
+    assert validation_audit["episodes"] == 5
+    assert validation_audit["baseline"]["accuracy"] == pytest.approx(0.0)
+    assert validation_audit["optimized"]["accuracy"] == pytest.approx(1.0)
 
     assert summary["models"]["Qwen3-1.7B-Base"]["42"]["baseline_validation"] == {
         "episodes": 5,
@@ -569,45 +584,51 @@ def test_raw_metrics_summary_aggregates_correctly() -> None:
 
 
 def test_extract_reflection_usage_none_lm() -> None:
-    tokens, cost = _extract_reflection_usage(None)
-    assert tokens == 0
-    assert cost == 0.0
+    usage = _extract_reflection_usage(None)
+    assert usage["total_tokens"] == 0
+    assert usage["known_total_tokens"] == 0
+    assert usage["total_cost_usd"] == 0.0
+    assert usage["known_cost_usd"] == 0.0
 
 
 def test_extract_reflection_usage_no_history_attr() -> None:
     lm = SimpleNamespace()  # no `history` attribute
-    tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 0
-    assert cost == 0.0
+    usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 0
+    assert usage["total_cost_usd"] == 0.0
 
 
 def test_extract_reflection_usage_empty_history() -> None:
     lm = SimpleNamespace(history=[])
-    tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 0
-    assert cost == 0.0
+    usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 0
+    assert usage["total_cost_usd"] == 0.0
 
 
 def test_extract_reflection_usage_non_dict_entry_ignored() -> None:
     lm = SimpleNamespace(history=["not a dict", 42, None])
-    tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 0
-    assert cost == 0.0
+    usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 0
+    assert usage["total_cost_usd"] == 0.0
 
 
 def test_extract_reflection_usage_with_tokens_only() -> None:
     history = [{"usage": {"total_tokens": 150}, "response": None}]
     lm = SimpleNamespace(history=history)
-    tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 150
-    assert cost == 0.0
+    usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 150
+    assert usage["known_total_tokens"] == 150
+    assert usage["total_cost_usd"] is None
+    assert usage["cost_data_coverage"] == 0.0
 
 
 def test_extract_reflection_usage_missing_usage_key() -> None:
     history = [{"response": None}]
     lm = SimpleNamespace(history=history)
-    tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 0
+    usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] is None
+    assert usage["known_total_tokens"] == 0
+    assert usage["token_data_coverage"] == 0.0
 
 
 def test_extract_reflection_usage_completion_cost_exception() -> None:
@@ -618,9 +639,10 @@ def test_extract_reflection_usage_completion_cost_exception() -> None:
         "trajectory_aware_gym.experiments.runner.completion_cost",
         side_effect=ValueError("fail"),
     ):
-        tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 10
-    assert cost == 0.0
+        usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 10
+    assert usage["total_cost_usd"] is None
+    assert usage["known_cost_usd"] == 0.0
 
 
 def test_extract_reflection_usage_accumulates_multiple_entries() -> None:
@@ -629,8 +651,9 @@ def test_extract_reflection_usage_accumulates_multiple_entries() -> None:
         {"usage": {"total_tokens": 100}, "response": None},
     ]
     lm = SimpleNamespace(history=history)
-    tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 150
+    usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 150
+    assert usage["known_total_tokens"] == 150
 
 
 def test_extract_reflection_usage_adds_numeric_completion_cost() -> None:
@@ -640,9 +663,9 @@ def test_extract_reflection_usage_adds_numeric_completion_cost() -> None:
         "trajectory_aware_gym.experiments.runner.completion_cost",
         return_value=0.123,
     ):
-        tokens, cost = _extract_reflection_usage(lm)
-    assert tokens == 11
-    assert cost == pytest.approx(0.123)
+        usage = _extract_reflection_usage(lm)
+    assert usage["total_tokens"] == 11
+    assert usage["total_cost_usd"] == pytest.approx(0.123)
 
 
 # ── dataset/eval helpers ───────────────────────────────────────────────────
@@ -748,10 +771,14 @@ def test_run_heldout_eval_rollouts_and_summary(monkeypatch: pytest.MonkeyPatch) 
 
     assert len(results) == 4
     assert summary["episodes_attempted"] == 4
+    assert summary["episodes_completed"] == 4
+    assert summary["episodes_scorable"] == 4
     assert summary["episodes"] == 4
     assert summary["failed"] == 0
     assert summary["successes"] == 2
     assert summary["success_rate"] == pytest.approx(0.5)
+    assert summary["completion_rate"] == pytest.approx(1.0)
+    assert summary["attempted_success_rate"] == pytest.approx(0.5)
     assert summary["correct"] == 2
     assert summary["accuracy"] == pytest.approx(0.5)
     # ThreadPoolExecutor order is non-deterministic; sort by episode_index.
@@ -761,6 +788,49 @@ def test_run_heldout_eval_rollouts_and_summary(monkeypatch: pytest.MonkeyPatch) 
         (2, 200, "p2"),
         (3, 201, None),
     ]
+
+
+def test_run_heldout_eval_records_failure_manifest_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
+    eval_examples = [
+        SimpleNamespace(seed=100, problem="p1"),
+        SimpleNamespace(seed=200, problem="p2"),
+    ]
+
+    def fake_run_eval_task(task, config, task_model_id, experiment_run_id=None):
+        if task.episode_index == 1:
+            raise RuntimeError("eval boom")
+        return _make_episode_result(
+            f"eval-{task.episode_index}",
+            success=True,
+            cost=0.0,
+            tokens=1,
+        )
+
+    monkeypatch.setattr(runner_module, "_eval_examples", lambda cfg: eval_examples)
+    monkeypatch.setattr(runner_module, "_run_eval_task", fake_run_eval_task)
+
+    results, summary = runner_module._run_heldout_eval(
+        config=config,
+        task_model_id="ollama/qwen3-1.7b-base",
+        instructions="prompt",
+    )
+
+    assert len(results) == 1
+    assert summary["episodes_attempted"] == 2
+    assert summary["episodes_completed"] == 1
+    assert summary["episodes_scorable"] == 1
+    assert summary["failed"] == 1
+    assert summary["timed_out"] == 0
+    failure_records = summary["failure_records"]
+    assert len(failure_records) == 1
+    assert failure_records[0]["episode_index"] == 1
+    assert failure_records[0]["seed"] == 200
+    assert failure_records[0]["status"] == "exception"
+    assert failure_records[0]["error_type"] == "RuntimeError"
+    assert "RuntimeError: eval boom" in failure_records[0]["traceback"]
 
 
 # ── _extract_task_usage ────────────────────────────────────────────────────
@@ -783,6 +853,23 @@ def test_extract_task_usage_accumulates() -> None:
     assert summary["total_cost_usd"] == pytest.approx(0.30)
     assert summary["known_total_tokens"] == 30
     assert summary["known_cost_usd"] == pytest.approx(0.30)
+
+
+def test_format_eval_detail_line_includes_all_denominators() -> None:
+    detail = _format_eval_detail_line(
+        {
+            "episodes_attempted": 500,
+            "episodes_completed": 392,
+            "episodes_scorable": 392,
+            "failed": 108,
+            "timed_out": 12,
+            "metrics_unavailable": 3,
+        }
+    )
+
+    assert detail == (
+        "attempted=500 completed=392 scorable=392 failed=108 timed_out=12 metrics_unavailable=3"
+    )
 
 
 # ── _extract_fitness_history ───────────────────────────────────────────────
@@ -1173,18 +1260,29 @@ def _default_eval_summary(
     episodes: int = 1,
     successes: int = 1,
     correct: int = 1,
+    *,
+    failure_records: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     total = episodes
-    return {
+    summary = {
         "episodes_attempted": total,
+        "episodes_completed": total,
+        "episodes_scorable": total,
         "episodes": total,
         "failed": 0,
+        "timed_out": 0,
+        "metrics_unavailable": 0,
         "successes": successes,
         "success_rate": (successes / total) if total else 0.0,
+        "completion_rate": 1.0 if total else 0.0,
+        "attempted_success_rate": (successes / total) if total else 0.0,
         "correct": correct,
         "accuracy": (correct / total) if total else 0.0,
         "temperature_eval": 0.0,
     }
+    if failure_records is not None:
+        summary["failure_records"] = failure_records
+    return summary
 
 
 def _setup_fake_runner(
@@ -2116,6 +2214,11 @@ def test_run_experiment_resume_gepa_done_preserves_saved_phase_artifacts(
     assert raw_summary["scope"] == "heldout_eval"
     assert raw_summary["heldout_total"]["episodes"] == 2
     assert raw_summary["heldout_total"]["successes"] == 2
+    validation_audit = json.loads(
+        (replication_dir / "validation_audit.json").read_text(encoding="utf-8")
+    )
+    assert validation_audit["source"] == "resume_saved_result"
+    assert validation_audit["details_available"] is False
 
     run_report = json.loads((replication_dir / "run_report.json").read_text(encoding="utf-8"))
     assert run_report["cost_type"] == "actual"
@@ -2312,6 +2415,23 @@ def test_run_experiment_records_logging_summary_in_metadata(
     _setup_fake_runner(monkeypatch, runner_module)
     monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
     monkeypatch.setattr(runner_module, "update_experiment_run", lambda *a, **k: None)
+    from trajectory_aware_gym.metrics.run_report import RunReport
+
+    monkeypatch.setattr(
+        runner_module,
+        "build_run_report",
+        lambda **kwargs: RunReport(
+            experiment_run_id=kwargs["experiment_run_id"],
+            config_name="quick-test",
+            operator="test",
+            provider="ollama",
+            task_model_id="ollama/qwen3-1.7b-base",
+            environment_id="math:Orz57K",
+            seed=42,
+            cost_type="unavailable",
+            logging_summary=kwargs["logging_summary"],
+        ),
+    )
     summary = run_experiment(
         RunExperimentArgs(
             config_path=QUICK_TEST_CONFIG,
@@ -2323,3 +2443,241 @@ def test_run_experiment_records_logging_summary_in_metadata(
     replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
     metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
     assert metadata["logging_summary"]["status"] == "complete"
+
+
+def test_run_experiment_writes_eval_failure_manifest_and_logging_event(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    _setup_fake_runner(monkeypatch, runner_module)
+
+    eval_calls = {"count": 0}
+
+    def fake_eval(**kwargs):
+        eval_calls["count"] += 1
+        if eval_calls["count"] == 1:
+            return (
+                [_make_episode_result("baseline-ok", success=True, cost=0.01, tokens=1)],
+                {
+                    "episodes_attempted": 2,
+                    "episodes_completed": 1,
+                    "episodes_scorable": 1,
+                    "episodes": 1,
+                    "failed": 1,
+                    "timed_out": 0,
+                    "metrics_unavailable": 0,
+                    "successes": 1,
+                    "success_rate": 1.0,
+                    "completion_rate": 0.5,
+                    "attempted_success_rate": 0.5,
+                    "correct": 1,
+                    "accuracy": 1.0,
+                    "temperature_eval": 0.0,
+                    "failure_records": [
+                        {
+                            "episode_index": 1,
+                            "seed": 43,
+                            "status": "exception",
+                            "timed_out": False,
+                            "error_type": "RuntimeError",
+                            "error_repr": "RuntimeError('baseline boom')",
+                        }
+                    ],
+                },
+            )
+        return (
+            [_make_episode_result("optimized-ok", success=True, cost=0.01, tokens=1)],
+            _default_eval_summary(episodes=1, successes=1, correct=1),
+        )
+
+    monkeypatch.setattr(runner_module, "_run_heldout_eval", fake_eval)
+
+    run_experiment(
+        RunExperimentArgs(
+            config_path=QUICK_TEST_CONFIG,
+            max_metric_calls=8,
+            results_root=tmp_path,
+        )
+    )
+
+    replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+    manifest_lines = (
+        (replication_dir / "eval_failure_manifest.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    )
+
+    assert metadata["logging_summary"]["status"] == "partial"
+    assert any(
+        event["kind"] == "eval_failures_recorded" for event in metadata["logging_summary"]["events"]
+    )
+    assert len(manifest_lines) == 1
+    manifest_row = json.loads(manifest_lines[0])
+    assert manifest_row["phase"] == "baseline"
+    assert manifest_row["episode_index"] == 1
+    assert manifest_row["error_type"] == "RuntimeError"
+    assert "RuntimeError('baseline boom')" == manifest_row["error_repr"]
+
+    raw_summary = json.loads(
+        (replication_dir / "raw_metrics_summary.json").read_text(encoding="utf-8")
+    )
+    assert raw_summary["eval_failure_manifest"]["count"] == 1
+    assert raw_summary["baseline_eval_denominators"]["failed"] == 1
+    assert raw_summary["heldout_total_denominators"]["episodes_attempted"] == 3
+
+
+def test_run_experiment_records_run_report_failure_in_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    _setup_fake_runner(monkeypatch, runner_module)
+    monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "update_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner_module,
+        "build_run_report",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("report boom")),
+    )
+
+    run_experiment(
+        RunExperimentArgs(
+            config_path=QUICK_TEST_CONFIG,
+            max_metric_calls=8,
+            results_root=tmp_path,
+        )
+    )
+
+    replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+
+    assert metadata["logging_summary"]["status"] == "partial"
+    assert any(
+        event["kind"] == "run_report_failed" for event in metadata["logging_summary"]["events"]
+    )
+    assert not (replication_dir / "run_report.json").exists()
+
+
+def test_run_experiment_records_experiment_run_update_failure_locally(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+    from trajectory_aware_gym.metrics.run_report import RunReport
+
+    _setup_fake_runner(monkeypatch, runner_module)
+    monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner_module,
+        "update_experiment_run",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("db boom")),
+    )
+    monkeypatch.setattr(
+        runner_module,
+        "build_run_report",
+        lambda **kwargs: RunReport(
+            experiment_run_id=kwargs["experiment_run_id"],
+            config_name="quick-test",
+            operator="test",
+            provider="ollama",
+            task_model_id="ollama/qwen3-1.7b-base",
+            environment_id="math:Orz57K",
+            seed=42,
+            cost_type="unavailable",
+            logging_summary=kwargs["logging_summary"],
+        ),
+    )
+
+    run_experiment(
+        RunExperimentArgs(
+            config_path=QUICK_TEST_CONFIG,
+            max_metric_calls=8,
+            results_root=tmp_path,
+        )
+    )
+
+    replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+    run_report = json.loads((replication_dir / "run_report.json").read_text(encoding="utf-8"))
+
+    assert metadata["logging_summary"]["status"] == "partial"
+    assert any(
+        event["kind"] == "experiment_run_update_failed"
+        for event in metadata["logging_summary"]["events"]
+    )
+    assert run_report["logging_summary"]["status"] == "partial"
+
+
+def test_run_experiment_salvages_training_trajectories_after_compile_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    train_result = GEMEpisodeResult(
+        trajectory=_make_training_trajectory("train-1", success=True),
+        log_path=None,
+        raw_metrics=_make_metric("train-1", success=True, cost=0.01, tokens=10),
+        logging_summary=EpisodeLoggingSummary(
+            status="complete",
+            persistence_requested=False,
+            trajectory_persisted=False,
+            metrics_available=True,
+        ),
+    )
+    save_calls: list[str] = []
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            self.episode_history = (train_result,)
+
+    class FakeSolverModule:
+        def __init__(self, runner, default_instructions: str, **kwargs):
+            self.instructions = default_instructions
+
+    class BrokenGEPA:
+        def __init__(self, **kwargs):
+            pass
+
+        def compile(self, student, trainset, valset):
+            raise RuntimeError("compile boom")
+
+    _stub_train_and_valsets(monkeypatch, runner_module)
+    monkeypatch.setattr(runner_module, "GEMEpisodeRunner", FakeRunner)
+    monkeypatch.setattr(runner_module, "GEMSolverModule", FakeSolverModule)
+    monkeypatch.setattr(runner_module.dspy, "GEPA", BrokenGEPA)
+    monkeypatch.setattr(runner_module.dspy, "configure", lambda **kwargs: None)
+    monkeypatch.setattr(runner_module, "_build_task_lm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(runner_module, "get_reflection_lm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "update_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner_module,
+        "save_trajectory",
+        lambda db_path, log, *, experiment_run_id=None: save_calls.append(experiment_run_id or ""),
+    )
+
+    summary = run_experiment(
+        RunExperimentArgs(
+            config_path=QUICK_TEST_CONFIG,
+            max_metric_calls=8,
+            results_root=tmp_path,
+            fail_fast=False,
+        )
+    )
+
+    replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+
+    assert summary["models"]["Qwen3-1.7B-Base"]["42"]["status"] == "failed"
+    assert len(save_calls) == 1
+    assert (replication_dir / "training_metrics.jsonl").exists()
+    assert any(
+        event["kind"] == "training_trajectories_salvaged"
+        for event in metadata["logging_summary"]["events"]
+    )

--- a/tests/unit/test_experiment_runner.py
+++ b/tests/unit/test_experiment_runner.py
@@ -152,6 +152,149 @@ def _stub_train_and_valsets(monkeypatch: pytest.MonkeyPatch, runner_module: Any)
     monkeypatch.setattr(runner_module, "_build_valset", lambda config: [SimpleNamespace()])
 
 
+def _setup_gepa_done_resume_replication(
+    tmp_path: Path,
+    *,
+    config_hash: str,
+    experiment_run_id: str,
+    gepa_phase_summary: dict[str, Any] | None,
+    training_rows: list[EpisodeRawMetrics] | None = None,
+    run_timestamp: str = "20260101T000000Z",
+) -> Path:
+    run_dir = tmp_path / "quick-test" / run_timestamp
+    replication_dir = run_dir / "Qwen3-1.7B-Base" / "replication_42"
+    replication_dir.mkdir(parents=True)
+    (run_dir / "run_summary.json").write_text(
+        json.dumps(
+            {
+                "run_id": f"quick-test-{run_timestamp}",
+                "config": "quick-test",
+                "config_hash": config_hash,
+                "started_at": "2026-01-01T00:00:00Z",
+                "finished_at": None,
+                "models": {"Qwen3-1.7B-Base": {"42": {"status": "running"}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    if training_rows:
+        _write_jsonl(replication_dir / "training_metrics.jsonl", training_rows)
+
+    metadata = {
+        "status": "gepa_done",
+        "experiment_run_id": experiment_run_id,
+        "config_hash": config_hash,
+        "started_at": "2026-01-01T00:00:00Z",
+        "seed": 42,
+        "model_name": "Qwen3-1.7B-Base",
+        "model_id": "ollama/qwen3-1.7b-base",
+        "result": {
+            "baseline_fitness": 0.2,
+            "final_fitness": 0.9,
+            "baseline_accuracy": 0.0,
+            "final_accuracy": 1.0,
+            "best_program_index": 1,
+            "optimized_instructions": "optimized prompt",
+        },
+    }
+    if gepa_phase_summary is not None:
+        metadata["gepa_phase_summary"] = gepa_phase_summary
+
+    (replication_dir / "run_metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    (replication_dir / "optimized_prompt.txt").write_text("optimized prompt", encoding="utf-8")
+    return replication_dir
+
+
+def _patch_gepa_done_resume_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    runner_module: Any,
+    *,
+    config: ExperimentConfig,
+    baseline_eval_results: list[GEMEpisodeResult],
+    eval_results: list[GEMEpisodeResult],
+) -> None:
+    from trajectory_aware_gym.metrics.run_report import RunReport
+
+    class ResumeRunner:
+        def __init__(self, **kwargs):
+            self.episode_history = ()
+
+    class FakeSolverModule:
+        def __init__(self, runner, default_instructions: str, **kwargs):
+            self.instructions = default_instructions
+
+    class ShouldNotCompileGEPA:
+        def __init__(self, **kwargs):
+            pass
+
+        def compile(self, student, trainset, valset):
+            raise AssertionError("GEPA compile should be skipped on gepa_done resume")
+
+    _stub_train_and_valsets(monkeypatch, runner_module)
+    monkeypatch.setattr(runner_module, "GEMEpisodeRunner", ResumeRunner)
+    monkeypatch.setattr(runner_module, "GEMSolverModule", FakeSolverModule)
+    monkeypatch.setattr(runner_module.dspy, "GEPA", ShouldNotCompileGEPA)
+    monkeypatch.setattr(runner_module.dspy, "configure", lambda **kwargs: None)
+    monkeypatch.setattr(runner_module, "_build_task_lm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(runner_module, "get_reflection_lm", lambda *a, **k: SimpleNamespace())
+
+    def fake_eval(**kwargs):
+        if kwargs["instructions"] == config.seed_prompt:
+            return (
+                baseline_eval_results,
+                _default_eval_summary(
+                    episodes=len(baseline_eval_results),
+                    successes=sum(
+                        1
+                        for result in baseline_eval_results
+                        if result.raw_metrics is not None and result.raw_metrics.success
+                    ),
+                    correct=sum(
+                        1
+                        for result in baseline_eval_results
+                        if result.raw_metrics is not None and result.raw_metrics.success
+                    ),
+                ),
+            )
+        return (
+            eval_results,
+            _default_eval_summary(
+                episodes=len(eval_results),
+                successes=sum(
+                    1
+                    for result in eval_results
+                    if result.raw_metrics is not None and result.raw_metrics.success
+                ),
+                correct=sum(
+                    1
+                    for result in eval_results
+                    if result.raw_metrics is not None and result.raw_metrics.success
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(runner_module, "_run_heldout_eval", fake_eval)
+    monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "update_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner_module,
+        "build_run_report",
+        lambda **kwargs: RunReport(
+            experiment_run_id=kwargs["experiment_run_id"],
+            config_name="quick-test",
+            operator="tester",
+            provider="ollama",
+            task_model_id="ollama/qwen3-1.7b-base",
+            environment_id="math:Orz57K",
+            seed=42,
+            baseline_validation=kwargs["baseline_validation_summary"],
+            optimized_validation=kwargs["optimized_validation_summary"],
+            cost_type=str(kwargs["cost_summary"]["cost_type"]),
+            logging_summary=kwargs["logging_summary"],
+        ),
+    )
+
+
 def test_resolve_gepa_budget_kwargs_uses_auto_mode_by_default() -> None:
     config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
     assert resolve_gepa_budget_kwargs(config, None) == {"auto": config.gepa_budget.mode}
@@ -2235,6 +2378,182 @@ def test_run_experiment_resume_gepa_done_preserves_saved_phase_artifacts(
     assert run_report["logging_summary"]["numeric_anomaly_count"] == 1
 
 
+@pytest.mark.parametrize(
+    ("saved_logging_summary", "expected_event_kind"),
+    [
+        (None, "gepa_logging_summary_missing"),
+        ({"status": "bogus"}, "gepa_logging_summary_invalid"),
+    ],
+)
+def test_run_experiment_resume_gepa_done_records_saved_logging_summary_issues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    saved_logging_summary: dict[str, Any] | None,
+    expected_event_kind: str,
+) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
+    snapshot = _build_effective_config_snapshot(
+        config,
+        seed_prompt=config.seed_prompt,
+        budget_mode=config.gepa_budget.mode,
+        seed_prompt_override=None,
+        budget_mode_override=None,
+        max_metric_calls_override=None,
+    )
+    config_hash = _config_hash(snapshot)
+    replication_dir = _setup_gepa_done_resume_replication(
+        tmp_path,
+        config_hash=config_hash,
+        experiment_run_id=f"resume-log-issue-{expected_event_kind}",
+        training_rows=[
+            _make_metric("train-1", success=True, cost=0.10, tokens=10),
+            _make_metric("train-2", success=False, cost=0.20, tokens=20),
+        ],
+        gepa_phase_summary={
+            "training_usage": {
+                "episodes": 2,
+                "total_tokens": 30,
+                "known_total_tokens": 30,
+                "token_data_coverage": 1.0,
+                "total_cost_usd": 0.3,
+                "known_cost_usd": 0.3,
+                "cost_data_coverage": 1.0,
+                "has_missing_cost_data": False,
+                "metrics_unavailable_episodes": 0,
+            },
+            "logging_summary": saved_logging_summary,
+            "reflection_usage": {
+                "total_tokens": 11,
+                "known_total_tokens": 11,
+                "token_data_coverage": 1.0,
+                "total_cost_usd": 0.11,
+                "known_cost_usd": 0.11,
+                "cost_data_coverage": 1.0,
+            },
+        },
+    )
+
+    _patch_gepa_done_resume_runtime(
+        monkeypatch,
+        runner_module,
+        config=config,
+        baseline_eval_results=[
+            _make_episode_result("baseline-1", success=True, cost=0.05, tokens=5)
+        ],
+        eval_results=[_make_episode_result("eval-1", success=True, cost=0.05, tokens=5)],
+    )
+
+    run_experiment(RunExperimentArgs(config_path=QUICK_TEST_CONFIG, results_root=tmp_path))
+
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["status"] == "completed"
+    assert metadata["logging_summary"]["status"] == "partial"
+    assert any(
+        event["kind"] == expected_event_kind for event in metadata["logging_summary"]["events"]
+    )
+
+    cost_summary = json.loads((replication_dir / "cost_summary.json").read_text(encoding="utf-8"))
+    assert cost_summary["training_task_model_tokens"] == 30
+    assert cost_summary["reflection_tokens"] == 11
+    assert cost_summary["total_cost"] == pytest.approx(0.51)
+
+    validation_audit = json.loads(
+        (replication_dir / "validation_audit.json").read_text(encoding="utf-8")
+    )
+    assert validation_audit["source"] == "resume_saved_result"
+
+    run_report = json.loads((replication_dir / "run_report.json").read_text(encoding="utf-8"))
+    assert run_report["logging_summary"]["status"] == "partial"
+    assert any(
+        event["kind"] == expected_event_kind for event in run_report["logging_summary"]["events"]
+    )
+
+
+def test_run_experiment_resume_gepa_done_records_missing_reflection_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
+    snapshot = _build_effective_config_snapshot(
+        config,
+        seed_prompt=config.seed_prompt,
+        budget_mode=config.gepa_budget.mode,
+        seed_prompt_override=None,
+        budget_mode_override=None,
+        max_metric_calls_override=None,
+    )
+    config_hash = _config_hash(snapshot)
+    replication_dir = _setup_gepa_done_resume_replication(
+        tmp_path,
+        config_hash=config_hash,
+        experiment_run_id="resume-reflection-missing",
+        training_rows=[
+            _make_metric("train-1", success=True, cost=0.10, tokens=10),
+            _make_metric("train-2", success=False, cost=0.20, tokens=20),
+        ],
+        gepa_phase_summary={
+            "training_usage": {
+                "episodes": 2,
+                "total_tokens": 30,
+                "known_total_tokens": 30,
+                "token_data_coverage": 1.0,
+                "total_cost_usd": 0.3,
+                "known_cost_usd": 0.3,
+                "cost_data_coverage": 1.0,
+                "has_missing_cost_data": False,
+                "metrics_unavailable_episodes": 0,
+            },
+            "logging_summary": {
+                "status": "complete",
+                "trajectory_persisted_episodes": 2,
+                "trajectory_failed_episodes": 0,
+                "metrics_unavailable_episodes": 0,
+                "numeric_anomaly_count": 0,
+                "events": [],
+                "events_truncated": False,
+            },
+        },
+    )
+
+    _patch_gepa_done_resume_runtime(
+        monkeypatch,
+        runner_module,
+        config=config,
+        baseline_eval_results=[
+            _make_episode_result("baseline-1", success=True, cost=0.05, tokens=5)
+        ],
+        eval_results=[_make_episode_result("eval-1", success=True, cost=0.05, tokens=5)],
+    )
+
+    run_experiment(RunExperimentArgs(config_path=QUICK_TEST_CONFIG, results_root=tmp_path))
+
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["status"] == "completed"
+    assert metadata["logging_summary"]["status"] == "partial"
+    assert metadata["logging_summary"]["trajectory_persisted_episodes"] == 2
+    assert any(
+        event["kind"] == "gepa_reflection_usage_missing"
+        for event in metadata["logging_summary"]["events"]
+    )
+
+    cost_summary = json.loads((replication_dir / "cost_summary.json").read_text(encoding="utf-8"))
+    assert cost_summary["reflection_tokens"] is None
+    assert cost_summary["reflection_cost"] is None
+    assert cost_summary["total_tokens"] is None
+    assert cost_summary["total_cost"] is None
+    assert cost_summary["total_tokens_known"] == 40
+    assert cost_summary["total_cost_known"] == pytest.approx(0.4)
+    assert cost_summary["cost_type"] == "partial"
+
+    run_report = json.loads((replication_dir / "run_report.json").read_text(encoding="utf-8"))
+    assert run_report["cost_type"] == "partial"
+    assert run_report["logging_summary"]["status"] == "partial"
+
+
 def test_run_experiment_saves_experiment_run_record(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -2376,6 +2695,7 @@ def test_run_experiment_writes_run_report_json(
     # Mock build_run_report to avoid needing a real DB.
     from trajectory_aware_gym.metrics.run_report import RunReport
 
+    captured_kwargs: dict[str, object] = {}
     fake_report = RunReport(
         experiment_run_id="fake-id",
         config_name="quick-test",
@@ -2386,7 +2706,12 @@ def test_run_experiment_writes_run_report_json(
         seed=42,
         cost_type="unavailable",
     )
-    monkeypatch.setattr(runner_module, "build_run_report", lambda **kw: fake_report)
+
+    def _fake_build_run_report(**kwargs: object) -> RunReport:
+        captured_kwargs.update(kwargs)
+        return fake_report
+
+    monkeypatch.setattr(runner_module, "build_run_report", _fake_build_run_report)
 
     run_experiment(
         RunExperimentArgs(
@@ -2403,6 +2728,7 @@ def test_run_experiment_writes_run_report_json(
     assert report_data["config_name"] == "quick-test"
     assert report_data["provider"] == "ollama"
     assert "logging_summary" in report_data
+    assert isinstance(captured_kwargs["finished_at"], str)
 
 
 def test_run_experiment_records_logging_summary_in_metadata(

--- a/tests/unit/test_experiment_runner.py
+++ b/tests/unit/test_experiment_runner.py
@@ -43,6 +43,7 @@ from trajectory_aware_gym.experiments.runner import (
 )
 from trajectory_aware_gym.metrics import EpisodeRawMetrics
 from trajectory_aware_gym.models.experiment import ExperimentConfig, FitnessOverride
+from trajectory_aware_gym.models.reflection_usage import ReflectionUsageSummary
 from trajectory_aware_gym.storage.models import EpisodeLoggingSummary
 
 QUICK_TEST_CONFIG = Path("experiments/quick-test/config.yaml")
@@ -161,18 +162,25 @@ def _setup_gepa_done_resume_replication(
     training_rows: list[EpisodeRawMetrics] | None = None,
     run_timestamp: str = "20260101T000000Z",
 ) -> Path:
-    run_dir = tmp_path / "quick-test" / run_timestamp
-    replication_dir = run_dir / "Qwen3-1.7B-Base" / "replication_42"
+    # Derive config-dependent names from the on-disk quick-test config so a rename
+    # of the model or seed there does not require this helper to be updated.
+    config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
+    task_model = config.task_models[0]
+    seed = config.seeds.replication_seeds[0]
+    config_name = config.name
+
+    run_dir = tmp_path / config_name / run_timestamp
+    replication_dir = run_dir / task_model.name / f"replication_{seed}"
     replication_dir.mkdir(parents=True)
     (run_dir / "run_summary.json").write_text(
         json.dumps(
             {
-                "run_id": f"quick-test-{run_timestamp}",
-                "config": "quick-test",
+                "run_id": f"{config_name}-{run_timestamp}",
+                "config": config_name,
                 "config_hash": config_hash,
                 "started_at": "2026-01-01T00:00:00Z",
                 "finished_at": None,
-                "models": {"Qwen3-1.7B-Base": {"42": {"status": "running"}}},
+                "models": {task_model.name: {str(seed): {"status": "running"}}},
             }
         ),
         encoding="utf-8",
@@ -185,9 +193,9 @@ def _setup_gepa_done_resume_replication(
         "experiment_run_id": experiment_run_id,
         "config_hash": config_hash,
         "started_at": "2026-01-01T00:00:00Z",
-        "seed": 42,
-        "model_name": "Qwen3-1.7B-Base",
-        "model_id": "ollama/qwen3-1.7b-base",
+        "seed": seed,
+        "model_name": task_model.name,
+        "model_id": task_model.model_id,
         "result": {
             "baseline_fitness": 0.2,
             "final_fitness": 0.9,
@@ -276,17 +284,20 @@ def _patch_gepa_done_resume_runtime(
     monkeypatch.setattr(runner_module, "_run_heldout_eval", fake_eval)
     monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
     monkeypatch.setattr(runner_module, "update_experiment_run", lambda *a, **k: None)
+    task_model = config.task_models[0]
+    provider = task_model.model_id.split("/", 1)[0] if "/" in task_model.model_id else "unknown"
+    seed = config.seeds.replication_seeds[0]
     monkeypatch.setattr(
         runner_module,
         "build_run_report",
         lambda **kwargs: RunReport(
             experiment_run_id=kwargs["experiment_run_id"],
-            config_name="quick-test",
+            config_name=config.name,
             operator="tester",
-            provider="ollama",
-            task_model_id="ollama/qwen3-1.7b-base",
-            environment_id="math:Orz57K",
-            seed=42,
+            provider=provider,
+            task_model_id=task_model.model_id,
+            environment_id=config.environment.gem_env_id,
+            seed=seed,
             baseline_validation=kwargs["baseline_validation_summary"],
             optimized_validation=kwargs["optimized_validation_summary"],
             cost_type=str(kwargs["cost_summary"]["cost_type"]),
@@ -469,7 +480,12 @@ def test_run_experiment_writes_full_replication_artifacts(
     monkeypatch.setattr(
         runner_module,
         "_extract_reflection_usage",
-        lambda reflection_lm: (7, 0.07),
+        lambda reflection_lm: ReflectionUsageSummary(
+            total_tokens=7,
+            known_total_tokens=7,
+            total_cost_usd=0.07,
+            known_cost_usd=0.07,
+        ),
     )
     monkeypatch.setattr(
         runner_module,
@@ -522,11 +538,13 @@ def test_run_experiment_writes_full_replication_artifacts(
         "episodes": 5,
         "correct": 0,
         "accuracy": 0.0,
+        "scorable": 0,
     }
     assert metadata["optimized_validation"] == {
         "episodes": 5,
         "correct": 5,
         "accuracy": 1.0,
+        "scorable": 0,
     }
     assert metadata["baseline_eval"]["accuracy"] == 1.0
     assert metadata["baseline_eval"]["episodes"] == 1
@@ -566,11 +584,13 @@ def test_run_experiment_writes_full_replication_artifacts(
         "episodes": 5,
         "correct": 0,
         "accuracy": 0.0,
+        "scorable": 0,
     }
     assert summary["models"]["Qwen3-1.7B-Base"]["42"]["optimized_validation"] == {
         "episodes": 5,
         "correct": 5,
         "accuracy": 1.0,
+        "scorable": 0,
     }
     assert summary["models"]["Qwen3-1.7B-Base"]["42"]["status"] == "completed"
 
@@ -726,89 +746,94 @@ def test_raw_metrics_summary_aggregates_correctly() -> None:
 # ── _extract_reflection_usage ──────────────────────────────────────────────
 
 
-def test_extract_reflection_usage_none_lm() -> None:
-    usage = _extract_reflection_usage(None)
-    assert usage["total_tokens"] == 0
-    assert usage["known_total_tokens"] == 0
-    assert usage["total_cost_usd"] == 0.0
-    assert usage["known_cost_usd"] == 0.0
+_SENTINEL_RESPONSE = object()
 
 
-def test_extract_reflection_usage_no_history_attr() -> None:
-    lm = SimpleNamespace()  # no `history` attribute
+@pytest.mark.parametrize(
+    (
+        "lm",
+        "expected_total_tokens",
+        "expected_known_total_tokens",
+        "expected_total_cost_usd",
+        "expected_known_cost_usd",
+        "expected_token_coverage",
+        "expected_cost_coverage",
+    ),
+    [
+        # (None LM, no-history attr, empty list, non-dict entries) all collapse to empty summary.
+        (None, 0, 0, 0.0, 0.0, 1.0, 1.0),
+        (SimpleNamespace(), 0, 0, 0.0, 0.0, 1.0, 1.0),
+        (SimpleNamespace(history=[]), 0, 0, 0.0, 0.0, 1.0, 1.0),
+        (SimpleNamespace(history=["not a dict", 42, None]), 0, 0, 0.0, 0.0, 1.0, 1.0),
+        # Tokens present but no response -> cost coverage 0, tokens fully known.
+        (
+            SimpleNamespace(history=[{"usage": {"total_tokens": 150}, "response": None}]),
+            150,
+            150,
+            None,
+            0.0,
+            1.0,
+            0.0,
+        ),
+        # Missing usage key -> tokens coverage 0, totals None.
+        (SimpleNamespace(history=[{"response": None}]), None, 0, None, 0.0, 0.0, 0.0),
+        # Multiple entries accumulate known totals.
+        (
+            SimpleNamespace(
+                history=[
+                    {"usage": {"total_tokens": 50}, "response": None},
+                    {"usage": {"total_tokens": 100}, "response": None},
+                ]
+            ),
+            150,
+            150,
+            None,
+            0.0,
+            1.0,
+            0.0,
+        ),
+    ],
+)
+def test_extract_reflection_usage_from_history(
+    lm: Any,
+    expected_total_tokens: int | None,
+    expected_known_total_tokens: int,
+    expected_total_cost_usd: float | None,
+    expected_known_cost_usd: float,
+    expected_token_coverage: float,
+    expected_cost_coverage: float,
+) -> None:
     usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 0
-    assert usage["total_cost_usd"] == 0.0
-
-
-def test_extract_reflection_usage_empty_history() -> None:
-    lm = SimpleNamespace(history=[])
-    usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 0
-    assert usage["total_cost_usd"] == 0.0
-
-
-def test_extract_reflection_usage_non_dict_entry_ignored() -> None:
-    lm = SimpleNamespace(history=["not a dict", 42, None])
-    usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 0
-    assert usage["total_cost_usd"] == 0.0
-
-
-def test_extract_reflection_usage_with_tokens_only() -> None:
-    history = [{"usage": {"total_tokens": 150}, "response": None}]
-    lm = SimpleNamespace(history=history)
-    usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 150
-    assert usage["known_total_tokens"] == 150
-    assert usage["total_cost_usd"] is None
-    assert usage["cost_data_coverage"] == 0.0
-
-
-def test_extract_reflection_usage_missing_usage_key() -> None:
-    history = [{"response": None}]
-    lm = SimpleNamespace(history=history)
-    usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] is None
-    assert usage["known_total_tokens"] == 0
-    assert usage["token_data_coverage"] == 0.0
+    assert usage.total_tokens == expected_total_tokens
+    assert usage.known_total_tokens == expected_known_total_tokens
+    assert usage.total_cost_usd == expected_total_cost_usd
+    assert usage.known_cost_usd == pytest.approx(expected_known_cost_usd)
+    assert usage.token_data_coverage == pytest.approx(expected_token_coverage)
+    assert usage.cost_data_coverage == pytest.approx(expected_cost_coverage)
 
 
 def test_extract_reflection_usage_completion_cost_exception() -> None:
     """completion_cost raising an exception should be swallowed."""
-    history = [{"usage": {"total_tokens": 10}, "response": object()}]
-    lm = SimpleNamespace(history=history)
+    lm = SimpleNamespace(history=[{"usage": {"total_tokens": 10}, "response": _SENTINEL_RESPONSE}])
     with patch(
         "trajectory_aware_gym.experiments.runner.completion_cost",
         side_effect=ValueError("fail"),
     ):
         usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 10
-    assert usage["total_cost_usd"] is None
-    assert usage["known_cost_usd"] == 0.0
-
-
-def test_extract_reflection_usage_accumulates_multiple_entries() -> None:
-    history = [
-        {"usage": {"total_tokens": 50}, "response": None},
-        {"usage": {"total_tokens": 100}, "response": None},
-    ]
-    lm = SimpleNamespace(history=history)
-    usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 150
-    assert usage["known_total_tokens"] == 150
+    assert usage.total_tokens == 10
+    assert usage.total_cost_usd is None
+    assert usage.known_cost_usd == 0.0
 
 
 def test_extract_reflection_usage_adds_numeric_completion_cost() -> None:
-    history = [{"usage": {"total_tokens": 11}, "response": object()}]
-    lm = SimpleNamespace(history=history)
+    lm = SimpleNamespace(history=[{"usage": {"total_tokens": 11}, "response": _SENTINEL_RESPONSE}])
     with patch(
         "trajectory_aware_gym.experiments.runner.completion_cost",
         return_value=0.123,
     ):
         usage = _extract_reflection_usage(lm)
-    assert usage["total_tokens"] == 11
-    assert usage["total_cost_usd"] == pytest.approx(0.123)
+    assert usage.total_tokens == 11
+    assert usage.total_cost_usd == pytest.approx(0.123)
 
 
 # ── dataset/eval helpers ───────────────────────────────────────────────────
@@ -931,6 +956,61 @@ def test_run_heldout_eval_rollouts_and_summary(monkeypatch: pytest.MonkeyPatch) 
         (2, 200, "p2"),
         (3, 201, None),
     ]
+
+
+def test_run_heldout_eval_records_timeout_manifest_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wall-clock TimeoutError in as_completed populates timed_out records, not exception records."""
+    import concurrent.futures as cf
+    import threading
+
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    config = ExperimentConfig.from_yaml(QUICK_TEST_CONFIG)
+    eval_examples = [
+        SimpleNamespace(seed=500, problem="slow1"),
+        SimpleNamespace(seed=600, problem="slow2"),
+    ]
+
+    # Workers block on an event that never fires, guaranteeing every future is
+    # still `not done()` when the wall-clock timeout is raised.
+    block_until = threading.Event()
+
+    def fake_run_eval_task(task, config, task_model_id, experiment_run_id=None):
+        block_until.wait(timeout=5.0)
+        return _make_episode_result(f"eval-{task.episode_index}", success=True, cost=0.0, tokens=1)
+
+    def fake_as_completed(future_map, timeout=None):
+        if False:
+            yield
+        raise TimeoutError
+
+    monkeypatch.setattr(runner_module, "_eval_examples", lambda cfg: eval_examples)
+    monkeypatch.setattr(runner_module, "_run_eval_task", fake_run_eval_task)
+    monkeypatch.setattr(cf, "as_completed", fake_as_completed)
+
+    try:
+        results, summary = runner_module._run_heldout_eval(
+            config=config,
+            task_model_id=config.task_models[0].model_id,
+            instructions="prompt",
+        )
+    finally:
+        block_until.set()
+
+    rollouts = config.eval_protocol.rollouts_per_task
+    expected_attempted = len(eval_examples) * rollouts
+    assert results == []
+    assert summary["episodes_attempted"] == expected_attempted
+    assert summary["episodes_completed"] == 0
+    assert summary["timed_out"] == expected_attempted
+    assert summary["failed"] == expected_attempted
+    failure_records = summary["failure_records"]
+    assert len(failure_records) == expected_attempted
+    assert all(record["status"] == "timed_out" for record in failure_records)
+    assert all(record["error_type"] == "TimeoutError" for record in failure_records)
+    assert {record["seed"] for record in failure_records} == {
+        int(ex.seed) + rollout for ex in eval_examples for rollout in range(rollouts)
+    }
 
 
 def test_run_heldout_eval_records_failure_manifest_entries(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1473,7 +1553,12 @@ def _setup_fake_runner(
     monkeypatch.setattr(
         runner_module,
         "_extract_reflection_usage",
-        lambda lm: (reflection_tokens, reflection_cost),
+        lambda lm: ReflectionUsageSummary(
+            total_tokens=reflection_tokens,
+            known_total_tokens=reflection_tokens,
+            total_cost_usd=reflection_cost,
+            known_cost_usd=reflection_cost,
+        ),
     )
     monkeypatch.setattr(
         runner_module,
@@ -1736,7 +1821,9 @@ def test_run_experiment_continue_on_failure_runs_remaining_seeds(
     monkeypatch.setattr(runner_module.dspy, "configure", lambda **kwargs: None)
     monkeypatch.setattr(runner_module, "_build_task_lm", lambda *a, **k: SimpleNamespace())
     monkeypatch.setattr(runner_module, "get_reflection_lm", lambda *a, **k: SimpleNamespace())
-    monkeypatch.setattr(runner_module, "_extract_reflection_usage", lambda lm: (0, 0.0))
+    monkeypatch.setattr(
+        runner_module, "_extract_reflection_usage", lambda lm: ReflectionUsageSummary.empty()
+    )
     monkeypatch.setattr(
         runner_module,
         "_run_heldout_eval",
@@ -1851,7 +1938,9 @@ def test_run_experiment_result_none_when_no_detailed_results(
     monkeypatch.setattr(runner_module.dspy, "configure", lambda **kwargs: None)
     monkeypatch.setattr(runner_module, "_build_task_lm", lambda *a, **k: SimpleNamespace())
     monkeypatch.setattr(runner_module, "get_reflection_lm", lambda *a, **k: SimpleNamespace())
-    monkeypatch.setattr(runner_module, "_extract_reflection_usage", lambda lm: (0, 0.0))
+    monkeypatch.setattr(
+        runner_module, "_extract_reflection_usage", lambda lm: ReflectionUsageSummary.empty()
+    )
     monkeypatch.setattr(
         runner_module,
         "_run_heldout_eval",
@@ -2122,7 +2211,9 @@ def test_run_experiment_resume_gepa_done_reuses_experiment_run_id(
     monkeypatch.setattr(runner_module.dspy, "configure", lambda **kwargs: None)
     monkeypatch.setattr(runner_module, "_build_task_lm", lambda *a, **k: SimpleNamespace())
     monkeypatch.setattr(runner_module, "get_reflection_lm", lambda *a, **k: SimpleNamespace())
-    monkeypatch.setattr(runner_module, "_extract_reflection_usage", lambda lm: (0, 0.0))
+    monkeypatch.setattr(
+        runner_module, "_extract_reflection_usage", lambda lm: ReflectionUsageSummary.empty()
+    )
     monkeypatch.setattr(
         runner_module,
         "_run_heldout_eval",
@@ -3006,4 +3097,137 @@ def test_run_experiment_salvages_training_trajectories_after_compile_failure(
     assert any(
         event["kind"] == "training_trajectories_salvaged"
         for event in metadata["logging_summary"]["events"]
+    )
+
+
+def test_run_experiment_records_salvage_failure_event(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When the post-compile salvage path itself raises, it emits a salvage-failed event."""
+    import trajectory_aware_gym.experiments.runner as runner_module
+
+    train_result = GEMEpisodeResult(
+        trajectory=_make_training_trajectory("train-1", success=True),
+        log_path=None,
+        raw_metrics=_make_metric("train-1", success=True, cost=0.01, tokens=10),
+        logging_summary=EpisodeLoggingSummary(
+            status="complete",
+            persistence_requested=False,
+            trajectory_persisted=False,
+            metrics_available=True,
+        ),
+    )
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            self.episode_history = (train_result,)
+
+    class FakeSolverModule:
+        def __init__(self, runner, default_instructions: str, **kwargs):
+            self.instructions = default_instructions
+
+    class BrokenGEPA:
+        def __init__(self, **kwargs):
+            pass
+
+        def compile(self, student, trainset, valset):
+            raise RuntimeError("compile boom")
+
+    def exploding_persist(results, *, experiment_run_id, db_path=None):
+        raise RuntimeError("salvage disk full")
+
+    _stub_train_and_valsets(monkeypatch, runner_module)
+    monkeypatch.setattr(runner_module, "GEMEpisodeRunner", FakeRunner)
+    monkeypatch.setattr(runner_module, "GEMSolverModule", FakeSolverModule)
+    monkeypatch.setattr(runner_module.dspy, "GEPA", BrokenGEPA)
+    monkeypatch.setattr(runner_module.dspy, "configure", lambda **kwargs: None)
+    monkeypatch.setattr(runner_module, "_build_task_lm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(runner_module, "get_reflection_lm", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "update_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "_persist_training_trajectories", exploding_persist)
+
+    run_experiment(
+        RunExperimentArgs(
+            config_path=QUICK_TEST_CONFIG,
+            max_metric_calls=8,
+            results_root=tmp_path,
+            fail_fast=False,
+        )
+    )
+
+    replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+
+    salvage_failed_events = [
+        event
+        for event in metadata["logging_summary"]["events"]
+        if event["kind"] == "training_trajectory_salvage_failed"
+    ]
+    assert len(salvage_failed_events) == 1
+    # Error context is embedded in the message, not leaking as a traceback.
+    assert "RuntimeError" in salvage_failed_events[0]["message"]
+    assert "salvage disk full" in salvage_failed_events[0]["message"]
+    assert not any(
+        event["kind"] == "training_trajectories_salvaged"
+        for event in metadata["logging_summary"]["events"]
+    )
+
+
+def test_run_experiment_records_gepa_done_publish_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An exception from update_experiment_run(gepa_done) is surfaced without aborting the replication."""
+    import trajectory_aware_gym.experiments.runner as runner_module
+    from trajectory_aware_gym.metrics.run_report import RunReport
+
+    update_call_kinds: list[str] = []
+
+    def fake_update_experiment_run(*args, **kwargs):
+        status = kwargs.get("status")
+        update_call_kinds.append(status or "unknown")
+        if status == "gepa_done":
+            raise RuntimeError("gepa_done publish boom")
+
+    _setup_fake_runner(monkeypatch, runner_module)
+    monkeypatch.setattr(runner_module, "save_experiment_run", lambda *a, **k: None)
+    monkeypatch.setattr(runner_module, "update_experiment_run", fake_update_experiment_run)
+    monkeypatch.setattr(
+        runner_module,
+        "build_run_report",
+        lambda **kwargs: RunReport(
+            experiment_run_id=kwargs["experiment_run_id"],
+            config_name="quick-test",
+            operator="test",
+            provider="ollama",
+            task_model_id="ollama/qwen3-1.7b-base",
+            environment_id="math:Orz57K",
+            seed=42,
+            cost_type="unavailable",
+            logging_summary=kwargs["logging_summary"],
+        ),
+    )
+
+    run_experiment(
+        RunExperimentArgs(
+            config_path=QUICK_TEST_CONFIG,
+            max_metric_calls=8,
+            results_root=tmp_path,
+        )
+    )
+
+    replication_dir = _find_replication_dir(tmp_path, "quick-test", "Qwen3-1.7B-Base", 42)
+    metadata = json.loads((replication_dir / "run_metadata.json").read_text(encoding="utf-8"))
+
+    assert update_call_kinds[0] == "gepa_done"
+    # Replication still completed despite the gepa_done publish failure.
+    assert metadata["status"] == "completed"
+    gepa_phase_events = metadata["gepa_phase_summary"]["logging_summary"]["events"]
+    assert any(
+        event["kind"] == "experiment_run_update_failed"
+        and "gepa_done" in event["message"]
+        and "RuntimeError" in event["message"]
+        for event in gepa_phase_events
     )

--- a/tests/unit/test_gem_episode_runner.py
+++ b/tests/unit/test_gem_episode_runner.py
@@ -143,6 +143,32 @@ def test_generate_smoke_action_keeps_ollama_cost_unavailable_when_litellm_return
     assert llm_call.cost_type == "unavailable"
 
 
+def test_generate_smoke_action_marks_missing_usage_unknown(monkeypatch):
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="\\boxed{4}", reasoning_content=None))
+        ]
+    )
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+        lambda **kwargs: response,
+    )
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.completion_cost",
+        lambda *, completion_response: 0.01,
+    )
+
+    action, llm_call = generate_smoke_action(
+        model_id="ollama/qwen3-1.7b-base",
+        messages=[{"role": "user", "content": "Solve 2 + 2"}],
+        temperature=0.0,
+    )
+
+    assert action == "\\boxed{4}"
+    assert llm_call.token_usage_known is False
+    assert llm_call.total_tokens == 0
+
+
 def test_run_episode_executes_tool_call_before_final_action(monkeypatch):
     class FakeEnv:
         def reset(self, **kwargs):
@@ -309,6 +335,60 @@ def test_run_episode_sanitizes_non_finite_completion_cost(monkeypatch):
     assert result.logging_summary.numeric_anomaly_count == 1
     assert result.logging_summary.status == "partial"
     assert any(event.kind == "numeric_sanitized" for event in result.logging_summary.events)
+
+
+def test_run_episode_marks_missing_usage_unknown(monkeypatch):
+    class FakeEnv:
+        def reset(self, **kwargs):
+            return "Solve 2 + 2", {}
+
+        def step(self, action: str):
+            assert action == "\\boxed{4}"
+            return "Correct", 1.0, True, False, {"correct": True}
+
+        def close(self):
+            return None
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="\\boxed{4}", reasoning_content=None))
+        ]
+    )
+
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.make_env",
+        _fake_make_env_factory(FakeEnv()),
+    )
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.completion",
+        lambda **kwargs: response,
+    )
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.completion_cost",
+        lambda *, completion_response: 0.0123,
+    )
+    monkeypatch.setattr(
+        "trajectory_aware_gym.adapters.gem_episode_runner.settings.validate_aws",
+        lambda: None,
+    )
+
+    runner = GEMEpisodeRunner(
+        environment_id="math:Orz57K",
+        model_id="bedrock/us.meta.llama3-2-1b-instruct-v1:0",
+        temperature=0.0,
+        max_steps=1,
+    )
+
+    result = runner.run_episode("Solve carefully.", persist=False)
+
+    assert result.trajectory is not None
+    llm_call = result.trajectory.steps[0].llm_calls[0]
+    assert llm_call.token_usage_known is False
+    assert result.raw_metrics is not None
+    assert result.raw_metrics.total_tokens is None
+    assert result.raw_metrics.token_data_coverage == 0.0
+    assert result.logging_summary.status == "partial"
+    assert any(event.kind == "usage_missing" for event in result.logging_summary.events)
 
 
 def test_run_episode_save_failure_is_non_fatal(monkeypatch):

--- a/tests/unit/test_raw_metrics.py
+++ b/tests/unit/test_raw_metrics.py
@@ -322,6 +322,51 @@ def test_extract_metrics_reads_from_llm_calls_when_info_empty() -> None:
     assert metrics.cost_data_coverage == 1.0
 
 
+def test_extract_metrics_preserves_partial_llm_call_coverage() -> None:
+    """Unknown usage stays partial instead of turning into fake zero-token completeness."""
+    steps = [
+        TrajectoryStep(
+            step_index=1,
+            action="act",
+            observation="obs",
+            reward=1.0,
+            terminated=True,
+            truncated=False,
+            info={},
+            llm_calls=[
+                LLMCallMetadata(
+                    model_id="m",
+                    prompt_tokens=10,
+                    completion_tokens=5,
+                    total_tokens=15,
+                    token_usage_known=True,
+                    cost_usd=0.01,
+                    latency_ms=200.0,
+                ),
+                LLMCallMetadata(
+                    model_id="m",
+                    prompt_tokens=0,
+                    completion_tokens=0,
+                    total_tokens=0,
+                    token_usage_known=False,
+                    cost_usd=None,
+                    latency_ms=None,
+                ),
+            ],
+        )
+    ]
+    trajectory = _build_trajectory(steps=steps, total_reward=1.0, elapsed_seconds=1.0)
+    metrics = extract_episode_raw_metrics(trajectory)
+
+    assert metrics.total_tokens == 15
+    assert metrics.prompt_tokens == 10
+    assert metrics.completion_tokens == 5
+    assert metrics.llm_cost_usd == pytest.approx(0.01)
+    assert metrics.token_data_coverage == pytest.approx(0.5)
+    assert metrics.cost_data_coverage == pytest.approx(0.5)
+    assert metrics.llm_latency_data_coverage == pytest.approx(0.5)
+
+
 def test_extract_metrics_aggregates_multiple_llm_calls_per_step() -> None:
     """Multiple llm_calls within a single step are summed correctly."""
     steps = [

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -230,7 +230,12 @@ class TestRunReportModel:
             "task_model_cost": None,
             "task_model_cost_known": 0.01,
             "task_model_cost_data_coverage": 0.5,
-            "reflection_cost": 0.005,
+            "reflection_tokens": None,
+            "reflection_tokens_known": 200,
+            "reflection_token_data_coverage": 0.5,
+            "reflection_cost": None,
+            "reflection_cost_known": 0.005,
+            "reflection_cost_data_coverage": 0.5,
             "total_tokens": None,
             "total_tokens_known": 1200,
             "total_cost": None,
@@ -254,6 +259,10 @@ class TestRunReportModel:
         assert report.cost_type == "partial"
         assert report.total_cost_usd is None
         assert report.total_cost_known_usd == pytest.approx(0.015)
+        assert report.reflection_tokens is None
+        assert report.reflection_tokens_known == 200
+        assert report.reflection_cost_usd is None
+        assert report.reflection_cost_known_usd == pytest.approx(0.005)
         assert report.logging_summary == logging_summary
         assert report.normalized_cost_usd is None
 

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -266,6 +266,20 @@ class TestRunReportModel:
         assert report.logging_summary == logging_summary
         assert report.normalized_cost_usd is None
 
+    def test_finished_at_override_takes_precedence_over_db(self, tmp_path: Path) -> None:
+        record = _make_run_record().model_copy(update={"status": "running", "finished_at": None})
+        db = tmp_path / "test.db"
+        save_experiment_run(db, record)
+
+        report = build_run_report(
+            experiment_run_id=record.experiment_run_id,
+            db_path=db,
+            cost_summary=_COST_SUMMARY,
+            finished_at="2026-04-15T14:31:00Z",
+        )
+
+        assert report.finished_at == "2026-04-15T14:31:00Z"
+
     def test_mean_latency_is_scoped_to_experiment_run(self, tmp_path: Path) -> None:
         db = tmp_path / "test.db"
         record_a = _make_run_record().model_copy(update={"experiment_run_id": "run-a"})

--- a/tests/unit/test_trajectory_db.py
+++ b/tests/unit/test_trajectory_db.py
@@ -222,6 +222,7 @@ class TestSaveAndLoad:
         assert loaded.steps[0].tool_calls[0].duration_ms == 42.0
         assert len(loaded.steps[0].llm_calls) == 1
         assert loaded.steps[0].llm_calls[0].provider == "bedrock"
+        assert loaded.steps[0].llm_calls[0].token_usage_known is True
         assert len(loaded.steps[1].llm_calls) == 2
         assert loaded.steps[1].llm_calls[0].cost_usd == 0.001
 
@@ -272,6 +273,21 @@ class TestSaveAndLoad:
         loaded_lc = loaded.steps[0].llm_calls[0]
         assert loaded_lc.cost_usd == cost_usd
         assert loaded_lc.cost_type == cost_type
+
+    def test_llm_call_unknown_token_usage_round_trip(self, db_path):
+        lc = LLMCallMetadata(
+            model_id="bedrock/llama-8b",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            token_usage_known=False,
+        )
+        step = _make_step(reward=0.0, terminated=True, llm_calls=[lc])
+        log = _make_log(steps=[step])
+        save_trajectory(db_path, log)
+        loaded = load_trajectory_by_id(db_path, log.run_id)
+
+        assert loaded.steps[0].llm_calls[0].token_usage_known is False
 
     def test_seed_none_preserved(self, db_path):
         log = _make_log(seed=None)
@@ -674,6 +690,7 @@ class TestSchemaMigration:
         assert "experiment_run_id" in episode_columns
         assert "provider" in llm_call_columns
         assert "cost_type" in llm_call_columns
+        assert "token_usage_known" in llm_call_columns
         assert "duration_ms" in tool_call_columns
         assert (
             conn.execute("SELECT version FROM schema_meta").fetchone()["version"] == SCHEMA_VERSION
@@ -682,6 +699,7 @@ class TestSchemaMigration:
         loaded = load_trajectory_by_id(db_path, log.run_id)
         assert loaded.steps[0].llm_calls[0].provider == "bedrock"
         assert loaded.steps[0].llm_calls[0].cost_type == "actual"
+        assert loaded.steps[0].llm_calls[0].token_usage_known is True
 
     def test_new_db_records_schema_version(self, db_path):
         save_experiment_run(db_path, _make_experiment_run(experiment_run_id="schema-meta-run"))

--- a/tests/unit/test_trajectory_logger.py
+++ b/tests/unit/test_trajectory_logger.py
@@ -963,6 +963,7 @@ class TestExtractLLMCallsFromTracker:
         assert calls[0].prompt_tokens == 10
         assert calls[0].completion_tokens == 20
         assert calls[0].total_tokens == 30
+        assert calls[0].token_usage_known is True
 
     def test_single_model_multiple_calls(self):
         tracker = _FakeTracker(
@@ -1026,7 +1027,7 @@ class TestExtractLLMCallsFromTracker:
         calls = extract_llm_calls_from_tracker(tracker)
         assert calls[0].cost_usd is None
 
-    def test_missing_token_fields_default_to_zero(self):
+    def test_missing_token_fields_stay_unknown(self):
         tracker = _FakeTracker(
             {
                 "bedrock/qwen3-1.7b": [{}],
@@ -1037,6 +1038,22 @@ class TestExtractLLMCallsFromTracker:
         assert calls[0].prompt_tokens == 0
         assert calls[0].completion_tokens == 0
         assert calls[0].total_tokens == 0
+        assert calls[0].token_usage_known is False
+
+    def test_explicit_total_tokens_is_preserved(self):
+        tracker = _FakeTracker(
+            {
+                "bedrock/qwen3-1.7b": [
+                    {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 42},
+                ],
+            }
+        )
+        calls = extract_llm_calls_from_tracker(tracker)
+        assert len(calls) == 1
+        assert calls[0].prompt_tokens == 10
+        assert calls[0].completion_tokens == 20
+        assert calls[0].total_tokens == 42
+        assert calls[0].token_usage_known is True
 
     def test_integrates_with_add_step(self):
         tracker = _FakeTracker(


### PR DESCRIPTION
## Summary

- Preserve unknown token/cost data instead of coercing missing usage to `0`, across task-model logging, reflection summaries, SQLite persistence, and run reports.
- Make evaluation results more auditable by surfacing held-out denominators and writing explicit failure/validation audit artifacts.
- Record partial publication/logging failures more explicitly so degraded runs remain truthful instead of silently looking complete.

## Related Issues

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update
- [ ] Configuration change

## Changes Made

- Added `token_usage_known` to per-call LLM metadata and SQLite `llm_calls` rows so missing task-model usage remains explicitly unknown instead of being logged as fake zeroes.
- Updated task-model token extraction to rely on LiteLLM-normalized `response.usage` fields only; when usage is missing, the call is marked unknown and a structured `usage_missing` logging event is emitted.
- Fixed raw-metrics token coverage so coverage reflects the proportion of calls with known usage rather than treating missing usage as complete data.
- Extended reflection usage/cost aggregation to preserve `known` totals and coverage, and surfaced partial reflection data in `cost_summary.json` and `run_report.json`.
- Added held-out eval denominator transparency:
  - console output now includes `attempted`, `completed`, `scorable`, `failed`, `timed_out`, and `metrics_unavailable`
  - `raw_metrics_summary.json` now includes denominator metadata for baseline, optimized, and combined held-out eval
- Added `eval_failure_manifest.jsonl` to record held-out eval exceptions/timeouts with phase, episode index, seed, error type, and traceback.
- Added `validation_audit.json` so validation-side baseline vs. selected-program evidence is preserved, including a degraded-but-explicit resume path when only saved result summaries are available.
- Recorded best-effort publication failures (for example `run_report.json` generation or experiment-run DB updates) into structured `logging_summary` events instead of leaving them as terminal-only warnings.
- Preserved partial GEPA training trajectories on replication failure via best-effort salvage for postmortem analysis.
- Aligned the legacy DSPy tracker helper with the new unknown-usage semantics.
- Updated docs to describe the new artifacts and denominator semantics.
- Updated testing files to include force injected failure tests

## Testing

- [ ] Tests pass locally (`poe test`)
- [ ] Linting passes (`poe lint`)
- [ ] Type checking passes (`poe typecheck`)

### Test Commands Run

```bash
uv run pytest tests/unit/test_experiment_runner.py tests/unit/test_trajectory_logger.py --no-cov
uv run pytest tests/unit/test_gem_episode_runner.py tests/unit/test_raw_metrics.py tests/unit/test_trajectory_db.py tests/unit/test_run_report.py --no-cov
uv run ruff check src/trajectory_aware_gym/experiments/runner.py src/trajectory_aware_gym/adapters/trajectory_logger.py tests/unit/test_experiment_runner.py tests/unit/test_trajectory_logger.py docs/03-experiments/production_runner.md
uv run pyright src/trajectory_aware_gym/experiments/runner.py src/trajectory_aware_gym/adapters/trajectory_logger.py
uv run pre-commit run --all-files
```

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Cost/Token Tracking (if applicable)

| Metric | Value |
|--------|-------|
| Tokens used | N/A |
| Estimated cost | N/A |

## Screenshots (if applicable)

N/A

## Additional Notes

- This PR intentionally does **not** change the mathematical definition of eval accuracy; it keeps `accuracy = correct / scorable` and makes the denominator breakdown explicit instead.
- This PR improves logging faithfulness and auditability, but it does **not** address cross-machine determinism issues such as provider-side sampling seeding.
- General Python file logging (`logs/training.log`) is still out of scope for this patch; this PR focuses on truthful structured artifacts and experiment outputs.
```
